### PR TITLE
Overwrite the scope of scct from compile to test

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -79,7 +79,8 @@ object CacheableBuild extends Build {
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
     libraryDependencies ++= Seq(
       "com.typesafe" %% "scalalogging-slf4j" % "1.0.1",
-      "org.scalatest" %% "scalatest" % "2.0" % "test"
+      "org.scalatest" %% "scalatest" % "2.0" % "test",
+      "com.github.scct" %% "scct" % "0.3-SNAPSHOT" % "test"  // overwrite scope
       //"org.scalamock" %% "scalamock-scalatest-support" % "3.0.1" % "test"
     ),
     parallelExecution in Test := false


### PR DESCRIPTION
Unfortunately, scct plugin (or coveralls plugin) appends scct library in compile scope. Maybe it's different from what you expected.

``` xml
<dependency>
<groupId>com.github.scct</groupId>
<artifactId>scct_2.10</artifactId>
<version>0.3-SNAPSHOT</version>
</dependency>
```

http://oss.sonatype.org/content/repositories/releases/com/github/cb372/cacheable-core_2.10/0.1/cacheable-core_2.10-0.1.pom

see also: https://github.com/mtkopone/scct/issues/54
