### PR TITLE
Memoize exclude params

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,20 @@ new Bar(10).baz(42) // cached as "foo.Bar(10).baz(42)" -> 52
 new Bar(20).baz(42) // cached as "foo.Bar(20).baz(42)" -> 62
 ```
 
+#### Excluding parameters from the generated cache key
+
+If there are any parameters (either method arguments or class constructor arguments) that you don't want to include in the auto-generated cache key for memoization, you can exclude them using the `@cacheKeyExclude` annotation.
+
+For example:
+
+```scala
+def doSomething(userId: UserId)(implicit @cacheKeyExclude db: DBConnection) = memoize {
+  ...
+}
+```
+
+will only include the `userId` argument's value in its cache keys.
+
 ### Flags
 
 Cache GETs and/or PUTs can be temporarily disabled using flags. This can be useful if for example you want to skip the cache and read a value from the DB under certain conditions.

--- a/core/src/main/scala/scalacache/memoization/Macros.scala
+++ b/core/src/main/scala/scalacache/memoization/Macros.scala
@@ -124,7 +124,13 @@ object Macros {
 
   private def paramListsToTree(c: blackbox.Context)(symbolss: List[List[c.Symbol]]): c.Tree = {
     import c.universe._
-    val identss: List[List[Ident]] = symbolss.map(ss => ss.map(s => Ident(s.name)))
+    val cacheKeyExcludeType = c.typeOf[cacheKeyExclude]
+    def shouldExclude(s: c.Symbol) = {
+      s.annotations.exists(a => a.tree.tpe == cacheKeyExcludeType)
+    }
+    val identss: List[List[Ident]] = symbolss.map(ss => ss.collect {
+      case s if !shouldExclude(s) => Ident(s.name)
+    })
     listToTree(c)(identss.map(is => listToTree(c)(is)))
   }
 

--- a/core/src/main/scala/scalacache/memoization/annotations.scala
+++ b/core/src/main/scala/scalacache/memoization/annotations.scala
@@ -1,0 +1,6 @@
+package scalacache.memoization
+
+import scala.annotation.StaticAnnotation
+
+final class cacheKeyExclude extends StaticAnnotation
+

--- a/core/src/main/scala/scalacache/memoization/annotations.scala
+++ b/core/src/main/scala/scalacache/memoization/annotations.scala
@@ -2,5 +2,17 @@ package scalacache.memoization
 
 import scala.annotation.StaticAnnotation
 
+/**
+ * Add this annotation to method or class constructor parameters
+ * in order to exclude them from auto-generated cache keys.
+ *
+ * e.g.
+ *
+ * {{{
+ * def foo(a: Int, @cacheKeyExclude b: String, c: String): Int = memoize { ... }
+ * }}}
+ *
+ * will not include the value of the `b` parameter in its cache keys.
+ */
 final class cacheKeyExclude extends StaticAnnotation
 

--- a/core/src/test/scala/scalacache/memoization/CacheKeyExcludingConstructorParamsSpec.scala
+++ b/core/src/test/scala/scalacache/memoization/CacheKeyExcludingConstructorParamsSpec.scala
@@ -50,6 +50,12 @@ class CacheKeyExcludingConstructorParamsSpec extends FlatSpec with CacheKeySpecC
     }
   }
 
+  it should "exclude values of arguments annotated with @cacheKeyExclude" in {
+    checkCacheKey("scalacache.memoization.CacheKeySpecCommon.withExcludedParams(1, 3)()") {
+      withExcludedParams(1, "2", "3")(4)
+    }
+  }
+
   it should "work for a method inside a class" in {
     checkCacheKey("scalacache.memoization.AClass.insideClass(1)") {
       new AClass().insideClass(1)

--- a/core/src/test/scala/scalacache/memoization/CacheKeyIncludingConstructorParamsSpec.scala
+++ b/core/src/test/scala/scalacache/memoization/CacheKeyIncludingConstructorParamsSpec.scala
@@ -19,6 +19,15 @@ class CacheKeyIncludingConstructorParamsSpec extends FlatSpec with CacheKeySpecC
     }
   }
 
+  it should "exclude values of constructor params annotated with @cacheKeyExclude" in {
+    val instance = new ClassWithExcludedConstructorParam(50, 10)
+    instance.scalaCache = scalaCache
+
+    checkCacheKey("scalacache.memoization.ClassWithExcludedConstructorParam(50).foo(42)") {
+      instance.foo(42)
+    }
+  }
+
   it should "include values of all arguments for all argument lists" in {
     checkCacheKey("scalacache.memoization.CacheKeySpecCommon.multipleArgLists(1, 2)(3, 4)") {
       multipleArgLists(1, "2")("3", 4)
@@ -40,6 +49,12 @@ class CacheKeyIncludingConstructorParamsSpec extends FlatSpec with CacheKeySpecC
   it should "include function arguments as <functionN>" in {
     checkCacheKey("scalacache.memoization.CacheKeySpecCommon.functionArg(<function1>)") {
       functionArg((s: String) => s.toInt + 1)
+    }
+  }
+
+  it should "exclude values of arguments annotated with @cacheKeyExclude" in {
+    checkCacheKey("scalacache.memoization.CacheKeySpecCommon.withExcludedParams(1, 3)()") {
+      withExcludedParams(1, "2", "3")(4)
     }
   }
 

--- a/core/src/test/scala/scalacache/memoization/CacheKeySpecCommon.scala
+++ b/core/src/test/scala/scalacache/memoization/CacheKeySpecCommon.scala
@@ -41,6 +41,10 @@ trait CacheKeySpecCommon extends Suite with Matchers with ScalaFutures with Befo
     123
   }
 
+  def withExcludedParams(a: Int, @cacheKeyExclude b: String, c: String)(@cacheKeyExclude d: Int): Int = memoize {
+    123
+  }
+
 }
 
 class AClass(implicit val scalaCache: ScalaCache) {
@@ -81,5 +85,12 @@ class ClassWithConstructorParams(b: Int) {
   implicit var scalaCache: ScalaCache = null
   def foo(a: Int): Int = memoize {
     a + b
+  }
+}
+
+class ClassWithExcludedConstructorParam(b: Int, @cacheKeyExclude c: Int) {
+  implicit var scalaCache: ScalaCache = null
+  def foo(a: Int): Int = memoize {
+    a + b + c
   }
 }


### PR DESCRIPTION
Add a `@cacheKeyExclude` annotation. This can be used to exclude parameters from the cache keys that are auto-generated by `memoize`.