### PR TITLE
Fix import for memoization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you're using an in-memory cache (e.g. Guava) then this is fine. But if you're
 
 ```scala 
 import scalacache._
-import memoization._
+import scalacache.memoization._
 
 implicit val scalaCache = ScalaCache(new MyCache())
 


### PR DESCRIPTION
The import was wrong, the memoization package is in the scalacache package