### PR TITLE
Memoization of methods that return Futures

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ import memoization._
 
 implicit val scalaCache = ScalaCache(new MyCache())
 
-def getUser(id: Int): User = sync.memoize {
+def getUser(id: Int): User = memoizeSync {
   // Do DB lookup here...
   User(id, s"user${id}")
 }
@@ -173,7 +173,7 @@ For example, given the following method:
 package foo
 
 object Bar {
-  def baz(a: Int, b: String)(c: String): Int = sync.memoize {
+  def baz(a: Int, b: String)(c: String): Int = memoizeSync {
     // Reticulating splines...   
     123
   }
@@ -200,7 +200,7 @@ package foo
 
 class Bar(a: Int) {
 
-  def baz(b: Int): Int = memoize {
+  def baz(b: Int): Int = memoizeSync {
     a + b
   }
   
@@ -253,7 +253,7 @@ import memoization._
 
 implicit val scalaCache = ScalaCache(new MyCache())
 
-def getUser(id: Int)(implicit flags: Flags): User = memoize {
+def getUser(id: Int)(implicit flags: Flags): User = memoizeSync {
   // Do DB lookup here...
   User(id, s"user${id}")
 }

--- a/core/src/main/scala/scalacache/memoization/Macros.scala
+++ b/core/src/main/scala/scalacache/memoization/Macros.scala
@@ -10,13 +10,13 @@ class Macros(val c: blackbox.Context) {
 
   def memoizeImpl[A: c.WeakTypeTag](f: c.Expr[A])(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags]): Tree = {
     commonMacroImpl(scalaCache, { keyName =>
-      q"""_root_.scalacache.caching($keyName)($f)($scalaCache, $flags)"""
+      q"""_root_.scalacache.cachingSync($keyName)($f)($scalaCache, $flags)"""
     })
   }
 
   def memoizeImplWithTTL[A: c.WeakTypeTag](ttl: c.Expr[Duration])(f: c.Expr[A])(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags]): Tree = {
     commonMacroImpl(scalaCache, { keyName =>
-      q"""_root_.scalacache.cachingWithTTL($keyName)($ttl)($f)($scalaCache, $flags)"""
+      q"""_root_.scalacache.cachingSyncWithTTL($keyName)($ttl)($f)($scalaCache, $flags)"""
     })
   }
 

--- a/core/src/main/scala/scalacache/memoization/Macros.scala
+++ b/core/src/main/scala/scalacache/memoization/Macros.scala
@@ -27,13 +27,13 @@ class Macros(val c: blackbox.Context) {
 
   def memoizeSyncImpl[A: c.WeakTypeTag](f: c.Expr[A])(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags]): Tree = {
     commonMacroImpl(scalaCache, { keyName =>
-      q"""_root_.scalacache.cachingSync($keyName)($f)($scalaCache, $flags)"""
+      q"""_root_.scalacache.sync.caching($keyName)($f)($scalaCache, $flags)"""
     })
   }
 
   def memoizeSyncImplWithTTL[A: c.WeakTypeTag](ttl: c.Expr[Duration])(f: c.Expr[A])(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags]): Tree = {
     commonMacroImpl(scalaCache, { keyName =>
-      q"""_root_.scalacache.cachingSyncWithTTL($keyName)($ttl)($f)($scalaCache, $flags)"""
+      q"""_root_.scalacache.sync.cachingWithTTL($keyName)($ttl)($f)($scalaCache, $flags)"""
     })
   }
 

--- a/core/src/main/scala/scalacache/memoization/MemoizationConfig.scala
+++ b/core/src/main/scala/scalacache/memoization/MemoizationConfig.scala
@@ -1,7 +1,7 @@
 package scalacache.memoization
 
 /**
- * Configuration related to the behaviour of the [[scalacache.memoization.memoize()]] methods.
+ * Configuration related to the behaviour of the `scalacache.memoization.memoize{Sync}` methods.
  *
  * @param toStringConverter converter for generating a String cache key from information about a method call
  */

--- a/core/src/main/scala/scalacache/memoization/package.scala
+++ b/core/src/main/scala/scalacache/memoization/package.scala
@@ -1,5 +1,6 @@
 package scalacache
 
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.language.experimental.macros
 import scala.concurrent.duration._
 
@@ -22,7 +23,7 @@ package object memoization {
    * @tparam A type of the value to be cached
    * @return the result, either retrieved from the cache or calculated by executing the function `f`
    */
-  def memoize[A](f: => A)(implicit scalaCache: ScalaCache, flags: Flags): A = macro Macros.memoizeImpl[A]
+  def memoize[A](f: => Future[A])(implicit scalaCache: ScalaCache, flags: Flags, ec: ExecutionContext): Future[A] = macro Macros.memoizeImpl[A]
 
   /**
    * Perform the given operation and memoize its result to a cache before returning it.
@@ -40,7 +41,39 @@ package object memoization {
    * @tparam A type of the value to be cached
    * @return the result, either retrieved from the cache or calculated by executing the function `f`
    */
-  def memoize[A](ttl: Duration)(f: => A)(implicit scalaCache: ScalaCache, flags: Flags): A = macro Macros.memoizeImplWithTTL[A]
+  def memoize[A](ttl: Duration)(f: => Future[A])(implicit scalaCache: ScalaCache, flags: Flags, ec: ExecutionContext): Future[A] = macro Macros.memoizeImplWithTTL[A]
+
+  /**
+   * Perform the given operation and memoize its result to a cache before returning it.
+   * If the result is already in the cache, return it without performing the operation.
+   *
+   * The result is stored in the cache without a TTL, so it will remain until it is naturally evicted.
+   *
+   * @param f function that returns some result. This result is the valued that will be cached.
+   * @param scalaCache cache configuration
+   * @param flags flags to customize ScalaCache behaviour
+   * @tparam A type of the value to be cached
+   * @return the result, either retrieved from the cache or calculated by executing the function `f`
+   */
+  def memoizeSync[A](f: => A)(implicit scalaCache: ScalaCache, flags: Flags): A = macro Macros.memoizeSyncImpl[A]
+
+  /**
+   * Perform the given operation and memoize its result to a cache before returning it.
+   * If the result is already in the cache, return it without performing the operation.
+   *
+   * The result is stored in the cache with the given TTL. It will be evicted when the TTL is up.
+   *
+   * Note that if the result is currently in the cache, changing the TTL has no effect.
+   * TTL is only set once, when the result is added to the cache.
+   *
+   * @param ttl Time To Live. How long the result should be stored in the cache.
+   * @param f function that returns some result. This result is the valued that will be cached.
+   * @param scalaCache cache configuration
+   * @param flags flags to customize ScalaCache behaviour
+   * @tparam A type of the value to be cached
+   * @return the result, either retrieved from the cache or calculated by executing the function `f`
+   */
+  def memoizeSync[A](ttl: Duration)(f: => A)(implicit scalaCache: ScalaCache, flags: Flags): A = macro Macros.memoizeSyncImplWithTTL[A]
 
 }
 

--- a/core/src/main/scala/scalacache/memoization/package.scala
+++ b/core/src/main/scala/scalacache/memoization/package.scala
@@ -15,13 +15,20 @@ package object memoization {
    * Perform the given operation and memoize its result to a cache before returning it.
    * If the result is already in the cache, return it without performing the operation.
    *
+   * All of the above happens asynchronously, so a `Future` is returned immediately.
+   * Specifically:
+   * - when the cache lookup completes, if it is a miss, the function execution is started.
+   * - at some point after the function completes, the result is written asynchronously to the cache.
+   * - the Future returned from this method does not wait for the cache write before completing.
+   *
    * The result is stored in the cache without a TTL, so it will remain until it is naturally evicted.
    *
-   * @param f function that returns some result. This result is the valued that will be cached.
+   * @param f function that asynchronously returns some result. This result is the value that will be cached.
    * @param scalaCache cache configuration
    * @param flags flags to customize ScalaCache behaviour
+   * @param ec An ExecutionContext in which to execute operations on Futures
    * @tparam A type of the value to be cached
-   * @return the result, either retrieved from the cache or calculated by executing the function `f`
+   * @return a Future of the result, either retrieved from the cache or calculated by executing the function `f`
    */
   def memoize[A](f: => Future[A])(implicit scalaCache: ScalaCache, flags: Flags, ec: ExecutionContext): Future[A] = macro Macros.memoizeImpl[A]
 
@@ -29,17 +36,24 @@ package object memoization {
    * Perform the given operation and memoize its result to a cache before returning it.
    * If the result is already in the cache, return it without performing the operation.
    *
+   * All of the above happens asynchronously, so a `Future` is returned immediately.
+   * Specifically:
+   * - when the cache lookup completes, if it is a miss, the function execution is started.
+   * - at some point after the function completes, the result is written asynchronously to the cache.
+   * - the Future returned from this method does not wait for the cache write before completing.
+   *
    * The result is stored in the cache with the given TTL. It will be evicted when the TTL is up.
    *
    * Note that if the result is currently in the cache, changing the TTL has no effect.
    * TTL is only set once, when the result is added to the cache.
    *
    * @param ttl Time To Live. How long the result should be stored in the cache.
-   * @param f function that returns some result. This result is the valued that will be cached.
+   * @param f function that asynchronously returns some result. This result is the value that will be cached.
    * @param scalaCache cache configuration
    * @param flags flags to customize ScalaCache behaviour
+   * @param ec An ExecutionContext in which to execute operations on Futures
    * @tparam A type of the value to be cached
-   * @return the result, either retrieved from the cache or calculated by executing the function `f`
+   * @return a Future of the result, either retrieved from the cache or calculated by executing the function `f`
    */
   def memoize[A](ttl: Duration)(f: => Future[A])(implicit scalaCache: ScalaCache, flags: Flags, ec: ExecutionContext): Future[A] = macro Macros.memoizeImplWithTTL[A]
 
@@ -49,7 +63,9 @@ package object memoization {
    *
    * The result is stored in the cache without a TTL, so it will remain until it is naturally evicted.
    *
-   * @param f function that returns some result. This result is the valued that will be cached.
+   * Warning: may block indefinitely!
+   *
+   * @param f function that returns some result. This result is the value that will be cached.
    * @param scalaCache cache configuration
    * @param flags flags to customize ScalaCache behaviour
    * @tparam A type of the value to be cached
@@ -66,8 +82,10 @@ package object memoization {
    * Note that if the result is currently in the cache, changing the TTL has no effect.
    * TTL is only set once, when the result is added to the cache.
    *
+   * Warning: may block indefinitely!
+   *
    * @param ttl Time To Live. How long the result should be stored in the cache.
-   * @param f function that returns some result. This result is the valued that will be cached.
+   * @param f function that returns some result. This result is the value that will be cached.
    * @param scalaCache cache configuration
    * @param flags flags to customize ScalaCache behaviour
    * @tparam A type of the value to be cached

--- a/core/src/main/scala/scalacache/package.scala
+++ b/core/src/main/scala/scalacache/package.scala
@@ -2,15 +2,13 @@ import com.typesafe.scalalogging.StrictLogging
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ ExecutionContext, Await, Future }
-import scala.util.{ Failure, Success, Try }
+import scala.util.Try
 
 package object scalacache extends StrictLogging {
 
   class TypedApi[V](implicit val scalaCache: ScalaCache) {
 
     def get(keyParts: Any*)(implicit flags: Flags): Future[Option[V]] = getWithKey(toKey(keyParts))
-
-    def getSync(keyParts: Any*)(implicit flags: Flags): Option[V] = getSyncWithKey(toKey(keyParts))
 
     def put(keyParts: Any*)(value: V, ttl: Option[Duration] = None)(implicit flags: Flags): Future[Unit] =
       putWithKey(toKey(keyParts), value, ttl)
@@ -27,14 +25,6 @@ package object scalacache extends StrictLogging {
 
     def cachingWithTTL(keyParts: Any*)(ttl: Duration)(f: => Future[V])(implicit flags: Flags, execContext: ExecutionContext = ExecutionContext.global): Future[V] = {
       _caching(keyParts: _*)(Some(ttl))(f)
-    }
-
-    def cachingSync(keyParts: Any*)(f: => V)(implicit flags: Flags): V = {
-      _cachingSync(keyParts: _*)(None)(f)
-    }
-
-    def cachingSyncWithTTL(keyParts: Any*)(ttl: Duration)(f: => V)(implicit flags: Flags): V = {
-      _cachingSync(keyParts: _*)(Some(ttl))(f)
     }
 
     private def _caching(keyParts: Any*)(ttl: Option[Duration])(f: => Future[V])(implicit flags: Flags, execContext: ExecutionContext): Future[V] = {
@@ -62,16 +52,6 @@ package object scalacache extends StrictLogging {
       }
     }
 
-    /*
-    Note: we could put our clever trousers on and abstract over synchronicity by saying
-    `f` has to return an F[V] (where F is either a Future or an Id), but this would leak into the public API
-    and probably confuse a lot of users.
-     */
-    private def _cachingSync(keyParts: Any*)(ttl: Option[Duration])(f: => V)(implicit flags: Flags): V = {
-      val future = _caching(keyParts: _*)(ttl)(Future.successful(f))(flags, ExecutionContext.global)
-      Await.result(future, Duration.Inf)
-    }
-
     private def getWithKey(key: String)(implicit flags: Flags): Future[Option[V]] = {
       if (flags.readsEnabled) {
         scalaCache.cache.get(key)
@@ -81,9 +61,6 @@ package object scalacache extends StrictLogging {
       }
     }
 
-    private def getSyncWithKey(key: String)(implicit flags: Flags): Option[V] =
-      Await.result(getWithKey(key), Duration.Inf)
-
     private def putWithKey(key: String, value: V, ttl: Option[Duration] = None)(implicit flags: Flags): Future[Unit] = {
       if (flags.writesEnabled) {
         scalaCache.cache.put(key, value, ttl)
@@ -91,6 +68,36 @@ package object scalacache extends StrictLogging {
         logger.debug(s"Skipping cache PUT because cache writes are disabled. Key: $key")
         Future.successful(())
       }
+    }
+
+    /**
+     * Synchronous API, for the case when you don't want to deal with Futures.
+     */
+    object sync {
+
+      def get(keyParts: Any*)(implicit flags: Flags): Option[V] = getSyncWithKey(toKey(keyParts))
+
+      def caching(keyParts: Any*)(f: => V)(implicit flags: Flags): V = {
+        _cachingSync(keyParts: _*)(None)(f)
+      }
+
+      def cachingWithTTL(keyParts: Any*)(ttl: Duration)(f: => V)(implicit flags: Flags): V = {
+        _cachingSync(keyParts: _*)(Some(ttl))(f)
+      }
+
+      /*
+      Note: we could put our clever trousers on and abstract over synchronicity by saying
+      `f` has to return an F[V] (where F is either a Future or an Id), but this would leak into the public API
+      and probably confuse a lot of users.
+       */
+      private def _cachingSync(keyParts: Any*)(ttl: Option[Duration])(f: => V)(implicit flags: Flags): V = {
+        val future = _caching(keyParts: _*)(ttl)(Future.successful(f))(flags, ExecutionContext.global)
+        Await.result(future, Duration.Inf)
+      }
+
+      private def getSyncWithKey(key: String)(implicit flags: Flags): Option[V] =
+        Await.result(getWithKey(key), Duration.Inf)
+
     }
   }
 
@@ -129,14 +136,17 @@ package object scalacache extends StrictLogging {
     typed[V].get(keyParts: _*)
 
   /**
-   * Convenience method to get a value from the cache synchronously. Warning: may block indefinitely!
+   * Convenience method to get a value from the cache synchronously.
+   *
+   * Warning: may block indefinitely!
    *
    * @param keyParts data to be used to generate the cache key. This could be as simple as just a single String. See [[CacheKeyBuilder]].
    * @tparam V the type of the corresponding value
    * @return the value, if there is one
    */
+  @deprecated("This method has moved. Please use scalacache.sync.get", "0.7.0")
   def getSync[V](keyParts: Any*)(implicit scalaCache: ScalaCache, flags: Flags): Option[V] =
-    typed[V].getSync(keyParts: _*)
+    sync.get[V](keyParts: _*)
 
   /**
    * Insert the given key-value pair into the cache, with an optional Time To Live.
@@ -211,38 +221,59 @@ package object scalacache extends StrictLogging {
   def cachingWithTTL[V](keyParts: Any*)(ttl: Duration)(f: => Future[V])(implicit scalaCache: ScalaCache, flags: Flags, execContext: ExecutionContext = ExecutionContext.global): Future[V] =
     typed[V].cachingWithTTL(keyParts: _*)(ttl)(f)
 
-  /**
-   * Wrap the given block with a caching decorator.
-   * First look in the cache. If the value is found, then return it immediately.
-   * Otherwise run the block and save the result in the cache before returning it.
-   *
-   * Note: Because no TTL is specified, the result will be stored in the cache indefinitely.
-   *
-   * @param keyParts data to be used to generate the cache key. This could be as simple as just a single String. See [[CacheKeyBuilder]].
-   * @param f the block to run
-   * @tparam V the type of the block's result
-   * @return the result, either retrived from the cache or returned by the block
-   */
-  def cachingSync[V](keyParts: Any*)(f: => V)(implicit scalaCache: ScalaCache, flags: Flags): V =
-    typed[V].cachingSync(keyParts: _*)(f)
-
-  /**
-   * Wrap the given block with a caching decorator.
-   * First look in the cache. If the value is found, then return it immediately.
-   * Otherwise run the block and save the result in the cache before returning it.
-   *
-   * The result will be stored in the cache until the given TTL expires.
-   *
-   * @param keyParts data to be used to generate the cache key. This could be as simple as just a single String. See [[CacheKeyBuilder]].
-   * @param ttl Time To Live
-   * @param f the block to run
-   * @tparam V the type of the block's result
-   * @return the result, either retrived from the cache or returned by the block
-   */
-  def cachingSyncWithTTL[V](keyParts: Any*)(ttl: Duration)(f: => V)(implicit scalaCache: ScalaCache, flags: Flags): V =
-    typed[V].cachingSyncWithTTL(keyParts: _*)(ttl)(f)
-
   private def toKey(parts: Seq[Any])(implicit scalaCache: ScalaCache): String =
     scalaCache.keyBuilder.toCacheKey(parts)(scalaCache.cacheConfig)
+
+  /**
+   * Synchronous API, for the case when you don't want to deal with Futures.
+   */
+  object sync {
+
+    /**
+     * Convenience method to get a value from the cache synchronously.
+     *
+     * Warning: may block indefinitely!
+     *
+     * @param keyParts data to be used to generate the cache key. This could be as simple as just a single String. See [[CacheKeyBuilder]].
+     * @tparam V the type of the corresponding value
+     * @return the value, if there is one
+     */
+    def get[V](keyParts: Any*)(implicit scalaCache: ScalaCache, flags: Flags): Option[V] =
+      typed[V].sync.get(keyParts: _*)
+
+    /**
+     * Wrap the given block with a caching decorator.
+     * First look in the cache. If the value is found, then return it immediately.
+     * Otherwise run the block and save the result in the cache before returning it.
+     *
+     * Note: Because no TTL is specified, the result will be stored in the cache indefinitely.
+     *
+     * Warning: may block indefinitely!
+     *
+     * @param keyParts data to be used to generate the cache key. This could be as simple as just a single String. See [[CacheKeyBuilder]].
+     * @param f the block to run
+     * @tparam V the type of the block's result
+     * @return the result, either retrived from the cache or returned by the block
+     */
+    def caching[V](keyParts: Any*)(f: => V)(implicit scalaCache: ScalaCache, flags: Flags): V =
+      typed[V].sync.caching(keyParts: _*)(f)
+
+    /**
+     * Wrap the given block with a caching decorator.
+     * First look in the cache. If the value is found, then return it immediately.
+     * Otherwise run the block and save the result in the cache before returning it.
+     *
+     * The result will be stored in the cache until the given TTL expires.
+     *
+     * @param keyParts data to be used to generate the cache key. This could be as simple as just a single String. See [[CacheKeyBuilder]].
+     * @param ttl Time To Live
+     * @param f the block to run
+     * @tparam V the type of the block's result
+     * @return the result, either retrived from the cache or returned by the block
+     */
+    def cachingWithTTL[V](keyParts: Any*)(ttl: Duration)(f: => V)(implicit scalaCache: ScalaCache, flags: Flags): V =
+      typed[V].sync.cachingWithTTL(keyParts: _*)(ttl)(f)
+
+  }
 
 }

--- a/core/src/test/scala/issue42/Issue42Spec.scala
+++ b/core/src/test/scala/issue42/Issue42Spec.scala
@@ -23,7 +23,7 @@ class Issue42Spec extends FlatSpec with Matchers {
     User(id, generateNewName())
   }
 
-  def getUserWithTtl(id: Int)(implicit flags: Flags): User = memoize(1 days) {
+  def getUserWithTtl(id: Int)(implicit flags: Flags): User = memoizeSync(1 days) {
     User(id, generateNewName())
   }
 

--- a/core/src/test/scala/issue42/Issue42Spec.scala
+++ b/core/src/test/scala/issue42/Issue42Spec.scala
@@ -19,7 +19,7 @@ class Issue42Spec extends FlatSpec with Matchers {
 
   def generateNewName() = Random.alphanumeric.take(10).mkString
 
-  def getUser(id: Int)(implicit flags: Flags): User = cachingSync(id) {
+  def getUser(id: Int)(implicit flags: Flags): User = sync.caching(id) {
     User(id, generateNewName())
   }
 

--- a/core/src/test/scala/issue42/Issue42Spec.scala
+++ b/core/src/test/scala/issue42/Issue42Spec.scala
@@ -19,7 +19,7 @@ class Issue42Spec extends FlatSpec with Matchers {
 
   def generateNewName() = Random.alphanumeric.take(10).mkString
 
-  def getUser(id: Int)(implicit flags: Flags): User = caching(id) {
+  def getUser(id: Int)(implicit flags: Flags): User = cachingSync(id) {
     User(id, generateNewName())
   }
 

--- a/core/src/test/scala/sample/Sample.scala
+++ b/core/src/test/scala/sample/Sample.scala
@@ -3,7 +3,10 @@ package sample
 import scalacache._
 import memoization._
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
 import language.postfixOps
 
 case class User(id: Int, name: String)
@@ -16,14 +19,14 @@ object Sample extends App {
   class UserRepository {
     implicit val cacheConfig = ScalaCache(new MockCache())
 
-    def getUser(id: Int): User = memoize {
+    def getUser(id: Int): Future[User] = memoize {
       // Do DB lookup here...
-      User(id, s"user$id")
+      Future { User(id, s"user$id") }
     }
 
-    def withExpiry(id: Int): User = memoize(60 seconds) {
+    def withExpiry(id: Int): Future[User] = memoize(60 seconds) {
       // Do DB lookup here...
-      User(id, s"user$id")
+      Future { User(id, s"user$id") }
     }
 
   }

--- a/core/src/test/scala/scalacache/PackageObjectSpec.scala
+++ b/core/src/test/scala/scalacache/PackageObjectSpec.scala
@@ -128,11 +128,11 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
     }
   }
 
-  behavior of "#cachingSync"
+  behavior of "sync.caching"
 
   it should "run the block and cache its result with no TTL if the value is not found in the cache" in {
     var called = false
-    val result = scalacache.cachingSync("myKey") {
+    val result = scalacache.sync.caching("myKey") {
       called = true
       "result of block"
     }
@@ -150,7 +150,7 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
     cache.mmap.put("myKey", "value from cache")
 
     var called = false
-    val result = scalacache.cachingSync("myKey") {
+    val result = scalacache.sync.caching("myKey") {
       called = true
       "result of block"
     }
@@ -166,7 +166,7 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
     implicit val flags = Flags(readsEnabled = false)
 
     var called = false
-    val result = scalacache.cachingSync("myKey") {
+    val result = scalacache.sync.caching("myKey") {
       called = true
       "result of block"
     }
@@ -184,7 +184,7 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
     implicit val flags = Flags(writesEnabled = false)
 
     var called = false
-    val result = scalacache.cachingSync("myKey") {
+    val result = scalacache.sync.caching("myKey") {
       called = true
       "result of block"
     }
@@ -195,11 +195,11 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
     result should be("result of block")
   }
 
-  behavior of "#cachingSyncWithTTL"
+  behavior of "sync.cachingWithTTL"
 
   it should "run the block and cache its result with the given TTL if the value is not found in the cache" in {
     var called = false
-    val result = scalacache.cachingSyncWithTTL("myKey")(10.seconds) {
+    val result = scalacache.sync.cachingWithTTL("myKey")(10.seconds) {
       called = true
       "result of block"
     }
@@ -218,7 +218,7 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
     implicit val flags = Flags(readsEnabled = false)
 
     var called = false
-    val result = scalacache.cachingSyncWithTTL("myKey")(10.seconds) {
+    val result = scalacache.sync.cachingWithTTL("myKey")(10.seconds) {
       called = true
       "result of block"
     }
@@ -236,7 +236,7 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
     implicit val flags = Flags(writesEnabled = false)
 
     var called = false
-    val result = scalacache.cachingSyncWithTTL("myKey")(10.seconds) {
+    val result = scalacache.sync.cachingWithTTL("myKey")(10.seconds) {
       called = true
       "result of block"
     }

--- a/core/src/test/scala/scalacache/PackageObjectSpec.scala
+++ b/core/src/test/scala/scalacache/PackageObjectSpec.scala
@@ -139,8 +139,11 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
 
     cache.getCalledWithArgs(0) should be("myKey")
     called should be(true)
-    cache.putCalledWithArgs(0) should be("myKey", "result of block", None)
     result should be("result of block")
+
+    eventually {
+      cache.putCalledWithArgs(0) should be("myKey", "result of block", None)
+    }
   }
 
   it should "not run the block if the value is found in the cache" in {
@@ -170,8 +173,11 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
 
     cache.getCalledWithArgs should be('empty)
     called should be(true)
-    cache.putCalledWithArgs(0) should be("myKey", "result of block", None)
     result should be("result of block")
+
+    eventually {
+      cache.putCalledWithArgs(0) should be("myKey", "result of block", None)
+    }
   }
 
   it should "run the block but not cache its result if cache writes are disabled" in {
@@ -200,8 +206,11 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
 
     cache.getCalledWithArgs(0) should be("myKey")
     called should be(true)
-    cache.putCalledWithArgs(0) should be("myKey", "result of block", Some(10.seconds))
     result should be("result of block")
+
+    eventually {
+      cache.putCalledWithArgs(0) should be("myKey", "result of block", Some(10.seconds))
+    }
   }
 
   it should "run the block and cache its result with the given TTL if cache reads are disabled" in {
@@ -216,8 +225,11 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
 
     cache.getCalledWithArgs should be('empty)
     called should be(true)
-    cache.putCalledWithArgs(0) should be("myKey", "result of block", Some(10.seconds))
     result should be("result of block")
+
+    eventually {
+      cache.putCalledWithArgs(0) should be("myKey", "result of block", Some(10.seconds))
+    }
   }
 
   it should "run the block but not cache its result if cache writes are disabled" in {

--- a/core/src/test/scala/scalacache/memoization/CacheKeySpecCommon.scala
+++ b/core/src/test/scala/scalacache/memoization/CacheKeySpecCommon.scala
@@ -26,43 +26,43 @@ trait CacheKeySpecCommon extends Suite with Matchers with ScalaFutures with Befo
     }
   }
 
-  def multipleArgLists(a: Int, b: String)(c: String, d: Int): Int = memoize {
+  def multipleArgLists(a: Int, b: String)(c: String, d: Int): Int = memoizeSync {
     123
   }
 
   case class CaseClass(a: Int) { override def toString = "custom toString" }
-  def takesCaseClass(cc: CaseClass): Int = memoize {
+  def takesCaseClass(cc: CaseClass): Int = memoizeSync {
     123
   }
 
-  def lazyArg(a: => Int): Int = memoize {
+  def lazyArg(a: => Int): Int = memoizeSync {
     123
   }
 
-  def functionArg(a: String => Int): Int = memoize {
+  def functionArg(a: String => Int): Int = memoizeSync {
     123
   }
 
-  def withExcludedParams(a: Int, @cacheKeyExclude b: String, c: String)(@cacheKeyExclude d: Int): Int = memoize {
+  def withExcludedParams(a: Int, @cacheKeyExclude b: String, c: String)(@cacheKeyExclude d: Int): Int = memoizeSync {
     123
   }
 
 }
 
 class AClass(implicit val scalaCache: ScalaCache) {
-  def insideClass(a: Int): Int = memoize {
+  def insideClass(a: Int): Int = memoizeSync {
     123
   }
 
   class InnerClass {
-    def insideInnerClass(a: Int): Int = memoize {
+    def insideInnerClass(a: Int): Int = memoizeSync {
       123
     }
   }
   val inner = new InnerClass
 
   object InnerObject {
-    def insideInnerObject(a: Int): Int = memoize {
+    def insideInnerObject(a: Int): Int = memoizeSync {
       123
     }
   }
@@ -71,28 +71,28 @@ class AClass(implicit val scalaCache: ScalaCache) {
 trait ATrait {
   implicit val scalaCache: ScalaCache
 
-  def insideTrait(a: Int): Int = memoize {
+  def insideTrait(a: Int): Int = memoizeSync {
     123
   }
 }
 
 object AnObject {
   implicit var scalaCache: ScalaCache = null
-  def insideObject(a: Int): Int = memoize {
+  def insideObject(a: Int): Int = memoizeSync {
     123
   }
 }
 
 class ClassWithConstructorParams(b: Int) {
   implicit var scalaCache: ScalaCache = null
-  def foo(a: Int): Int = memoize {
+  def foo(a: Int): Int = memoizeSync {
     a + b
   }
 }
 
 class ClassWithExcludedConstructorParam(b: Int, @cacheKeyExclude c: Int) {
   implicit var scalaCache: ScalaCache = null
-  def foo(a: Int): Int = memoize {
+  def foo(a: Int): Int = memoizeSync {
     a + b + c
   }
 }

--- a/core/src/test/scala/scalacache/memoization/CacheKeySpecCommon.scala
+++ b/core/src/test/scala/scalacache/memoization/CacheKeySpecCommon.scala
@@ -1,11 +1,11 @@
 package scalacache.memoization
 
 import org.scalatest._
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 
 import scalacache.{ ScalaCache, MockCache }
 
-trait CacheKeySpecCommon extends Suite with Matchers with ScalaFutures with BeforeAndAfter {
+trait CacheKeySpecCommon extends Suite with Matchers with ScalaFutures with BeforeAndAfter with Eventually {
 
   val cache = new MockCache
   implicit def scalaCache: ScalaCache
@@ -19,8 +19,10 @@ trait CacheKeySpecCommon extends Suite with Matchers with ScalaFutures with Befo
     val value = call
 
     // Check that the value is in the cache, with the expected key
-    whenReady(cache.get(expectedKey)) { result =>
-      result should be(Some(value))
+    eventually {
+      whenReady(cache.get(expectedKey)) { result =>
+        result should be(Some(value))
+      }
     }
   }
 

--- a/core/src/test/scala/scalacache/memoization/SquerylIntegrationSpec.scala
+++ b/core/src/test/scala/scalacache/memoization/SquerylIntegrationSpec.scala
@@ -39,7 +39,7 @@ class SquerylIntegrationSpec extends FlatSpec with Matchers with BeforeAndAfterA
     val cache = new MockCache with LoggingCache
     implicit val scalaCache = ScalaCache(cache)
 
-    def findUser(userId: Int): Option[User] = memoize {
+    def findUser(userId: Int): Option[User] = memoizeSync {
       inTransaction {
         from(users)((u) =>
           select(u)

--- a/core/src/test/scala/scalacache/memoization/pkg/package.scala
+++ b/core/src/test/scala/scalacache/memoization/pkg/package.scala
@@ -5,7 +5,7 @@ import scalacache._
 package object pkg {
   implicit var scalaCache: ScalaCache = null
 
-  def insidePackageObject(a: Int): Int = memoize {
+  def insidePackageObject(a: Int): Int = memoizeSync {
     123
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.5")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
 

--- a/redis/src/test/scala/scalacache/redis/Issue32Spec.scala
+++ b/redis/src/test/scala/scalacache/redis/Issue32Spec.scala
@@ -22,7 +22,7 @@ class Issue32Spec
 
     implicit val scalaCache = ScalaCache(RedisCache(pool))
 
-    def getUser(id: Int): List[User] = memoize {
+    def getUser(id: Int): List[User] = memoizeSync {
       List(User(id, "Taro"))
     }
 

--- a/redis/src/test/scala/scalacache/redis/PlayIntegrationSpec.scala
+++ b/redis/src/test/scala/scalacache/redis/PlayIntegrationSpec.scala
@@ -42,7 +42,7 @@ object Global extends GlobalSettings {
     jedisPool.destroy()
   }
 
-  def getItems(ids: List[Int]): List[Item] = memoize {
+  def getItems(ids: List[Int]): List[Item] = memoizeSync {
     ids map { Item(_, "Chris") }
   }
 }


### PR DESCRIPTION
Fixes #59 

Adds asynchronous versions of `scalacache.caching`, `scalacache.cachingWithTTL` and `scalacache.memoization.memoize`. These methods wrap an `f: => Future[V]` and return a `Future[V]`.

This involves breaking API changes, as I took this opportunity to reorganise the API.

* What was `scalacache.caching` is now called `scalacache.sync.caching`.
* Same goes for `scalacache.cachingWithTTL`.
* What was `scalacache.memoization.memoize` is now called `scalacache.memoization.memoizeSync`.
* `scalacache.getSync` has been deprecated and replaced with `scalacache.sync.get`.


