### PR TITLE
Remove duplicated cache key generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: scala
 scala:
-  - 2.11.6
+  - 2.11.7
 jdk:
   - oraclejdk8
   - oraclejdk7
@@ -9,7 +9,7 @@ services:
   - memcached
   - redis
 script: 
-  - sbt ++2.11.6 coverage test 
+  - sbt ++2.11.7 coverage test 
   - sbt ++2.11.2 test
   - sbt ++2.11.0 test
 after_success: "sbt coverageAggregate coveralls"

--- a/core/src/main/scala/scalacache/package.scala
+++ b/core/src/main/scala/scalacache/package.scala
@@ -14,7 +14,7 @@ package object scalacache extends StrictLogging {
       putWithKey(toKey(keyParts), value, ttl)
 
     def remove(keyParts: Any*): Future[Unit] =
-      scalacache.remove(toKey(keyParts))
+      scalacache.remove(keyParts: _*)
 
     def removeAll(): Future[Unit] =
       scalacache.removeAll()

--- a/core/src/test/scala/scalacache/PackageObjectSpec.scala
+++ b/core/src/test/scala/scalacache/PackageObjectSpec.scala
@@ -66,6 +66,18 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
     cache.removeCalledWithArgs(0) should be("baz")
   }
 
+  it should "concatenate key parts correctly" in {
+    scalacache.remove("hey", "yeah")
+    cache.removeCalledWithArgs(0) should be("hey:yeah")
+  }
+
+  behavior of "typed.remove"
+
+  it should "concatenate key parts correctly" in {
+    scalacache.typed[String].remove("oh", "wow")
+    cache.removeCalledWithArgs(0) should be("oh:wow")
+  }
+
   behavior of "#caching"
 
   it should "run the block and cache its result asynchronously with no TTL if the value is not found in the cache" in {


### PR DESCRIPTION
This was harmless, but we were calling `toKey` twice, which is a bit silly.