### PR TITLE
- Initial commit, added optional TTL implementations of memoize

### DIFF
--- a/core/src/main/scala/scalacache/memoization/Macros.scala
+++ b/core/src/main/scala/scalacache/memoization/Macros.scala
@@ -25,9 +25,9 @@ class Macros(val c: blackbox.Context) {
     })
   }
 
-  def memoizeImplWithOptionalTTL[A: c.WeakTypeTag](optionalttl: c.Expr[Option[Duration]])(f: c.Tree)(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags], ec: c.Expr[ExecutionContext]): Tree = {
+  def memoizeImplWithOptionalTTL[A: c.WeakTypeTag](optionalTtl: c.Expr[Option[Duration]])(f: c.Tree)(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags], ec: c.Expr[ExecutionContext]): Tree = {
     commonMacroImpl(scalaCache, { keyName =>
-      q"""_root_.scalacache.cachingWithOptionalTTL($keyName)($optionalttl)($f)($scalaCache, $flags, $ec)"""
+      q"""_root_.scalacache.cachingWithOptionalTTL($keyName)($optionalTtl)($f)($scalaCache, $flags, $ec)"""
     })
   }
 
@@ -43,9 +43,9 @@ class Macros(val c: blackbox.Context) {
     })
   }
 
-  def memoizeSyncImplWithOptionalTTL[A: c.WeakTypeTag](optionalttl: c.Expr[Option[Duration]])(f: c.Expr[A])(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags]): Tree = {
+  def memoizeSyncImplWithOptionalTTL[A: c.WeakTypeTag](optionalTtl: c.Expr[Option[Duration]])(f: c.Expr[A])(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags]): Tree = {
     commonMacroImpl(scalaCache, { keyName =>
-      q"""_root_.scalacache.sync.cachingWithOptionalTTL($keyName)($optionalttl)($f)($scalaCache, $flags)"""
+      q"""_root_.scalacache.sync.cachingWithOptionalTTL($keyName)($optionalTtl)($f)($scalaCache, $flags)"""
     })
   }
 

--- a/core/src/main/scala/scalacache/memoization/Macros.scala
+++ b/core/src/main/scala/scalacache/memoization/Macros.scala
@@ -25,6 +25,12 @@ class Macros(val c: blackbox.Context) {
     })
   }
 
+  def memoizeImplWithOptionalTTL[A: c.WeakTypeTag](optionalttl: c.Expr[Option[Duration]])(f: c.Tree)(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags], ec: c.Expr[ExecutionContext]): Tree = {
+    commonMacroImpl(scalaCache, { keyName =>
+      q"""_root_.scalacache.cachingWithOptionalTTL($keyName)($optionalttl)($f)($scalaCache, $flags, $ec)"""
+    })
+  }
+
   def memoizeSyncImpl[A: c.WeakTypeTag](f: c.Expr[A])(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags]): Tree = {
     commonMacroImpl(scalaCache, { keyName =>
       q"""_root_.scalacache.sync.caching($keyName)($f)($scalaCache, $flags)"""
@@ -34,6 +40,12 @@ class Macros(val c: blackbox.Context) {
   def memoizeSyncImplWithTTL[A: c.WeakTypeTag](ttl: c.Expr[Duration])(f: c.Expr[A])(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags]): Tree = {
     commonMacroImpl(scalaCache, { keyName =>
       q"""_root_.scalacache.sync.cachingWithTTL($keyName)($ttl)($f)($scalaCache, $flags)"""
+    })
+  }
+
+  def memoizeSyncImplWithOptionalTTL[A: c.WeakTypeTag](optionalttl: c.Expr[Option[Duration]])(f: c.Expr[A])(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags]): Tree = {
+    commonMacroImpl(scalaCache, { keyName =>
+      q"""_root_.scalacache.sync.cachingWithOptionalTTL($keyName)($optionalttl)($f)($scalaCache, $flags)"""
     })
   }
 
@@ -71,9 +83,11 @@ class Macros(val c: blackbox.Context) {
 
     def getMethodSymbolRecursively(sym: Symbol): Symbol = {
       if (sym == null || sym == NoSymbol || sym.owner == sym)
-        c.abort(c.enclosingPosition,
+        c.abort(
+          c.enclosingPosition,
           "This memoize block does not appear to be inside a method. " +
-            "Memoize blocks must be placed inside methods, so that a cache key can be generated.")
+            "Memoize blocks must be placed inside methods, so that a cache key can be generated."
+        )
       else if (sym.isMethod)
         sym
       else

--- a/core/src/main/scala/scalacache/memoization/package.scala
+++ b/core/src/main/scala/scalacache/memoization/package.scala
@@ -71,16 +71,16 @@ package object memoization {
    *
    * Note that if the result is currently in the cache, changing the TTL has no effect.
    * TTL is only set once, when the result is added to the cache.
-   * 
-   * @param optionalttl Optional Time to Live. If defined, how long the result should be stored in the cache. 
+   *
+   * @param optionalTtl Optional Time to Live. If defined, how long the result should be stored in the cache.
    * @param f function that returns some result. This result is the value that will be cached.
    * @param scalaCache cache configuration
    * @param flags flags to customize ScalaCache behaviour
    * @tparam A type of the value to be cached
    * @return the result, either retrieved from the cache or calculated by executing the function `f`
    */
-  def memoize[A](optionalttl: Option[Duration])(f: => Future[A])(implicit scalaCache: ScalaCache, flags: Flags, ec: ExecutionContext): Future[A] = macro Macros.memoizeImplWithOptionalTTL[A]
-  
+  def memoize[A](optionalTtl: Option[Duration])(f: => Future[A])(implicit scalaCache: ScalaCache, flags: Flags, ec: ExecutionContext): Future[A] = macro Macros.memoizeImplWithOptionalTTL[A]
+
   /**
    * Perform the given operation and memoize its result to a cache before returning it.
    * If the result is already in the cache, return it without performing the operation.
@@ -128,13 +128,13 @@ package object memoization {
    *
    * Warning: may block indefinitely!
    *
-   * @param optionalttl Optional Time to Live. If defined, how long the result should be stored in the cache. 
+   * @param optionalTtl Optional Time to Live. If defined, how long the result should be stored in the cache.
    * @param f function that returns some result. This result is the value that will be cached.
    * @param scalaCache cache configuration
    * @param flags flags to customize ScalaCache behaviour
    * @tparam A type of the value to be cached
    * @return the result, either retrieved from the cache or calculated by executing the function `f`
    */
-  def memoizeSync[A](optionalttl: Option[Duration])(f: => A)(implicit scalaCache: ScalaCache, flags: Flags): A = macro Macros.memoizeSyncImplWithOptionalTTL[A]
+  def memoizeSync[A](optionalTtl: Option[Duration])(f: => A)(implicit scalaCache: ScalaCache, flags: Flags): A = macro Macros.memoizeSyncImplWithOptionalTTL[A]
 }
 

--- a/core/src/main/scala/scalacache/memoization/package.scala
+++ b/core/src/main/scala/scalacache/memoization/package.scala
@@ -60,6 +60,30 @@ package object memoization {
   /**
    * Perform the given operation and memoize its result to a cache before returning it.
    * If the result is already in the cache, return it without performing the operation.
+   * 
+   * All of the above happens asynchronously, so a `Future` is returned immediately.
+   * Specifically:
+   * - when the cache lookup completes, if it is a miss, the function execution is started.
+   * - at some point after the function completes, the result is written asynchronously to the cache.
+   * - the Future returned from this method does not wait for the cache write before completing.
+   *
+   * The result is stored in the cache with the given TTL. It will be evicted when the TTL is up.
+   *
+   * Note that if the result is currently in the cache, changing the TTL has no effect.
+   * TTL is only set once, when the result is added to the cache.
+   * 
+   * @param optionalttl Optional Time to Live. If defined, how long the result should be stored in the cache. 
+   * @param f function that returns some result. This result is the value that will be cached.
+   * @param scalaCache cache configuration
+   * @param flags flags to customize ScalaCache behaviour
+   * @tparam A type of the value to be cached
+   * @return the result, either retrieved from the cache or calculated by executing the function `f`
+   */
+  def memoize[A](optionalttl: Option[Duration])(f: => Future[A])(implicit scalaCache: ScalaCache, flags: Flags, ec: ExecutionContext): Future[A] = macro Macros.memoizeImplWithOptionalTTL[A]
+  
+  /**
+   * Perform the given operation and memoize its result to a cache before returning it.
+   * If the result is already in the cache, return it without performing the operation.
    *
    * The result is stored in the cache without a TTL, so it will remain until it is naturally evicted.
    *
@@ -93,5 +117,24 @@ package object memoization {
    */
   def memoizeSync[A](ttl: Duration)(f: => A)(implicit scalaCache: ScalaCache, flags: Flags): A = macro Macros.memoizeSyncImplWithTTL[A]
 
+  /**
+   * Perform the given operation and memoize its result to a cache before returning it.
+   * If the result is already in the cache, return it without performing the operation.
+   *
+   * The result is stored in the cache with the given TTL. It will be evicted when the TTL is up.
+   *
+   * Note that if the result is currently in the cache, changing the TTL has no effect.
+   * TTL is only set once, when the result is added to the cache.
+   *
+   * Warning: may block indefinitely!
+   *
+   * @param optionalttl Optional Time to Live. If defined, how long the result should be stored in the cache. 
+   * @param f function that returns some result. This result is the value that will be cached.
+   * @param scalaCache cache configuration
+   * @param flags flags to customize ScalaCache behaviour
+   * @tparam A type of the value to be cached
+   * @return the result, either retrieved from the cache or calculated by executing the function `f`
+   */
+  def memoizeSync[A](optionalttl: Option[Duration])(f: => A)(implicit scalaCache: ScalaCache, flags: Flags): A = macro Macros.memoizeSyncImplWithOptionalTTL[A]
 }
 

--- a/core/src/main/scala/scalacache/package.scala
+++ b/core/src/main/scala/scalacache/package.scala
@@ -27,6 +27,10 @@ package object scalacache extends StrictLogging {
       _caching(keyParts: _*)(Some(ttl))(f)
     }
 
+    def cachingWithOptionalTTL(keyParts: Any*)(optionalttl: Option[Duration])(f: => Future[V])(implicit flags: Flags, execContext: ExecutionContext = ExecutionContext.global): Future[V] = {
+      _caching(keyParts: _*)(optionalttl)(f)
+    }
+
     private def _caching(keyParts: Any*)(ttl: Option[Duration])(f: => Future[V])(implicit flags: Flags, execContext: ExecutionContext): Future[V] = {
       val key = toKey(keyParts)
 
@@ -273,6 +277,26 @@ package object scalacache extends StrictLogging {
      */
     def cachingWithTTL[V](keyParts: Any*)(ttl: Duration)(f: => V)(implicit scalaCache: ScalaCache, flags: Flags): V =
       typed[V].sync.cachingWithTTL(keyParts: _*)(ttl)(f)
+
+    /**
+     * Wrap the given block with a caching decorator.
+     * First look in the cache. If the value is found, then return it immediately.
+     * Otherwise run the block and save the result in the cache before returning it.
+     *
+     * The result will be stored in the cache until the given TTL expires.
+     *
+     * @param keyParts data to be used to generate the cache key. This could be as simple as just a single String. See [[CacheKeyBuilder]].
+     * @param optionalttl Optional Time To Live
+     * @param f the block to run
+     * @tparam V the type of the block's result
+     * @return the result, either retrived from the cache or returned by the block
+     */
+    def cachingWithOptionalTTL[V](keyParts: Any*)(optionalttl: Option[Duration])(f: => V)(implicit scalaCache: ScalaCache, flags: Flags): V = {
+      optionalttl match {
+        case Some(ttl) => typed[V].sync.cachingWithTTL(keyParts: _*)(ttl)(f)
+        case None => typed[V].sync.caching(keyParts: _*)(f)
+      }
+    }
 
   }
 

--- a/core/src/main/scala/scalacache/package.scala
+++ b/core/src/main/scala/scalacache/package.scala
@@ -225,6 +225,9 @@ package object scalacache extends StrictLogging {
   def cachingWithTTL[V](keyParts: Any*)(ttl: Duration)(f: => Future[V])(implicit scalaCache: ScalaCache, flags: Flags, execContext: ExecutionContext = ExecutionContext.global): Future[V] =
     typed[V].cachingWithTTL(keyParts: _*)(ttl)(f)
 
+  def cachingWithOptionalTtl[V](keyParts: Any*)(optionalTtl: Option[Duration])(f: => Future[V])(implicit scalaCache: ScalaCache, flags: Flags, execContext: ExecutionContext = ExecutionContext.global): Future[V] =
+    typed[V].cachingWithOptionalTTL(keyParts: _*)(optionalTtl)(f)
+
   private def toKey(parts: Seq[Any])(implicit scalaCache: ScalaCache): String =
     scalaCache.keyBuilder.toCacheKey(parts)(scalaCache.cacheConfig)
 

--- a/core/src/main/scala/scalacache/package.scala
+++ b/core/src/main/scala/scalacache/package.scala
@@ -27,8 +27,8 @@ package object scalacache extends StrictLogging {
       _caching(keyParts: _*)(Some(ttl))(f)
     }
 
-    def cachingWithOptionalTTL(keyParts: Any*)(optionalttl: Option[Duration])(f: => Future[V])(implicit flags: Flags, execContext: ExecutionContext = ExecutionContext.global): Future[V] = {
-      _caching(keyParts: _*)(optionalttl)(f)
+    def cachingWithOptionalTTL(keyParts: Any*)(optionalTtl: Option[Duration])(f: => Future[V])(implicit flags: Flags, execContext: ExecutionContext = ExecutionContext.global): Future[V] = {
+      _caching(keyParts: _*)(optionalTtl)(f)
     }
 
     private def _caching(keyParts: Any*)(ttl: Option[Duration])(f: => Future[V])(implicit flags: Flags, execContext: ExecutionContext): Future[V] = {
@@ -286,13 +286,13 @@ package object scalacache extends StrictLogging {
      * The result will be stored in the cache until the given TTL expires.
      *
      * @param keyParts data to be used to generate the cache key. This could be as simple as just a single String. See [[CacheKeyBuilder]].
-     * @param optionalttl Optional Time To Live
+     * @param optionalTtl Optional Time To Live
      * @param f the block to run
      * @tparam V the type of the block's result
      * @return the result, either retrived from the cache or returned by the block
      */
-    def cachingWithOptionalTTL[V](keyParts: Any*)(optionalttl: Option[Duration])(f: => V)(implicit scalaCache: ScalaCache, flags: Flags): V = {
-      optionalttl match {
+    def cachingWithOptionalTTL[V](keyParts: Any*)(optionalTtl: Option[Duration])(f: => V)(implicit scalaCache: ScalaCache, flags: Flags): V = {
+      optionalTtl match {
         case Some(ttl) => typed[V].sync.cachingWithTTL(keyParts: _*)(ttl)(f)
         case None => typed[V].sync.caching(keyParts: _*)(f)
       }


### PR DESCRIPTION
This just adds implementations of memoize with an optionalttl argument (i.e. `Option[Duration]`). Internally we use `Option[Duration]` often.

Let me know if you want to add unit tests for the additions, the change is however very trivial