### PR TITLE
- Fixed a typo with cachingWithOptionalTtl -> cachingWithOptionalTTL

### DIFF
--- a/core/src/main/scala/scalacache/package.scala
+++ b/core/src/main/scala/scalacache/package.scala
@@ -225,7 +225,7 @@ package object scalacache extends StrictLogging {
   def cachingWithTTL[V](keyParts: Any*)(ttl: Duration)(f: => Future[V])(implicit scalaCache: ScalaCache, flags: Flags, execContext: ExecutionContext = ExecutionContext.global): Future[V] =
     typed[V].cachingWithTTL(keyParts: _*)(ttl)(f)
 
-  def cachingWithOptionalTtl[V](keyParts: Any*)(optionalTtl: Option[Duration])(f: => Future[V])(implicit scalaCache: ScalaCache, flags: Flags, execContext: ExecutionContext = ExecutionContext.global): Future[V] =
+  def cachingWithOptionalTTL[V](keyParts: Any*)(optionalTtl: Option[Duration])(f: => Future[V])(implicit scalaCache: ScalaCache, flags: Flags, execContext: ExecutionContext = ExecutionContext.global): Future[V] =
     typed[V].cachingWithOptionalTTL(keyParts: _*)(optionalTtl)(f)
 
   private def toKey(parts: Seq[Any])(implicit scalaCache: ScalaCache): String =


### PR DESCRIPTION
Apologies, a typo was made when I wanted to make the release in a rush and hence created errors like these

```
/Users/matthewdedetrich/test/Main.scala:176: object cachingWithOptionalTTL is not a member of package scalacache
```

Have just fixed this with a new pull request