### PR TITLE
Support for other Redis variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,8 @@ val jedis = new Jedis(...)
 implicit val scalaCache = ScalaCache(RedisCache(jedis))
 ```
 
+ScalaCache also supports [sharded Redis](https://github.com/xetorthio/jedis/wiki/AdvancedUsage#shardedjedis) and [Redis Sentinel](http://redis.io/topics/sentinel). Just create a `ShardedRedisCache` or `SentinelRedisCache` respectively.
+
 ### LruMap (twitter-util)
 
 SBT:

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -79,7 +79,7 @@ object ScalaCacheBuild extends Build {
     .settings(implProjectSettings: _*)
     .settings(
       libraryDependencies ++= Seq(
-        "redis.clients" % "jedis" % "2.7.2"
+        "redis.clients" % "jedis" % "2.8.0"
       ) ++ playTesting
     )
     .dependsOn(core)

--- a/redis/src/main/scala/scalacache/redis/RedisCache.scala
+++ b/redis/src/main/scala/scalacache/redis/RedisCache.scala
@@ -1,10 +1,6 @@
 package scalacache.redis
 
-import scalacache.{ LoggingSupport, Cache }
-import scala.concurrent.duration._
-import com.typesafe.scalalogging.StrictLogging
-import redis.clients.jedis.{ JedisPool, Jedis }
-import java.nio.charset.Charset
+import redis.clients.jedis._
 import scala.concurrent.{ Future, ExecutionContext, blocking }
 
 /**
@@ -12,73 +8,18 @@ import scala.concurrent.{ Future, ExecutionContext, blocking }
  * @param customClassloader a classloader to use when deserializing objects from the cache.
  *                          If you are using Play, you should pass in `app.classloader`.
  */
-class RedisCache(jedisPool: JedisPool, override val customClassloader: Option[ClassLoader] = None)(implicit execContext: ExecutionContext = ExecutionContext.global)
-    extends Cache
-    with RedisSerialization
-    with LoggingSupport
-    with StrictLogging {
-
-  import RedisCache.StringWithUtf8Bytes
-
-  /**
-   * Get the value corresponding to the given key from the cache
-   * @param key cache key
-   * @tparam V the type of the corresponding value
-   * @return the value, if there is one
-   */
-  override def get[V](key: String) = Future {
-    blocking {
-      withJedisClient { client =>
-        val resultBytes = Option(client.get(key.utf8bytes))
-        val result = resultBytes.map(deserialize[V])
-        logCacheHitOrMiss(key, result)
-        result
-      }
-    }
-  }
-
-  /**
-   * Insert the given key-value pair into the cache, with an optional Time To Live.
-   * @param key cache key
-   * @param value corresponding value
-   * @param ttl Time To Live
-   * @tparam V the type of the corresponding value
-   */
-  override def put[V](key: String, value: V, ttl: Option[Duration]) = Future {
-    blocking {
-      withJedisClient { client =>
-        val keyBytes = key.utf8bytes
-        val valueBytes = serialize(value)
-        ttl match {
-          case None => client.set(keyBytes, valueBytes)
-          case Some(Duration.Zero) => client.set(keyBytes, valueBytes)
-          case Some(d) if d < 1.second => {
-            logger.warn("Because Redis (pre 2.6.12) does not support sub-second expiry, TTL of $d will be rounded up to 1 second")
-            client.setex(keyBytes, 1, valueBytes)
-          }
-          case Some(d) => client.setex(keyBytes, d.toSeconds.toInt, valueBytes)
-        }
-      }
-    }
-  }
-
-  /**
-   * Remove the given key and its associated value from the cache, if it exists.
-   * If the key is not in the cache, do nothing.
-   * @param key cache key
-   */
-  override def remove(key: String) = Future {
-    blocking {
-      withJedisClient { client =>
-        client.del(key.utf8bytes)
-      }
-    }
-  }
+class RedisCache(jedisPool: JedisPool, override val customClassloader: Option[ClassLoader] = None)(implicit val execContext: ExecutionContext = ExecutionContext.global)
+    extends RedisCacheBase {
 
   override def removeAll() = Future {
     blocking {
-      withJedisClient { client =>
-        client.flushDB()
+      withJedisCommands { jedis =>
+        val jedis = jedisPool.getResource()
+        try {
+          jedis.flushDB()
+        } finally {
+          jedis.close()
+        }
       }
     }
   }
@@ -87,7 +28,7 @@ class RedisCache(jedisPool: JedisPool, override val customClassloader: Option[Cl
     jedisPool.close()
   }
 
-  private def withJedisClient[T](f: Jedis => T): T = {
+  override def withJedisCommands[T](f: BinaryJedisCommands => T): T = {
     val jedis = jedisPool.getResource()
     try {
       f(jedis)
@@ -113,15 +54,6 @@ object RedisCache {
    */
   def apply(jedisPool: JedisPool, customClassloader: Option[ClassLoader] = None): RedisCache =
     new RedisCache(jedisPool, customClassloader)
-
-  private val utf8 = Charset.forName("UTF-8")
-
-  /**
-   * Enrichment class to convert String to UTF-8 byte array
-   */
-  private implicit class StringWithUtf8Bytes(val string: String) extends AnyVal {
-    def utf8bytes = string.getBytes(utf8)
-  }
 
 }
 

--- a/redis/src/main/scala/scalacache/redis/RedisCache.scala
+++ b/redis/src/main/scala/scalacache/redis/RedisCache.scala
@@ -8,32 +8,19 @@ import scala.concurrent.{ Future, ExecutionContext, blocking }
  * @param customClassloader a classloader to use when deserializing objects from the cache.
  *                          If you are using Play, you should pass in `app.classloader`.
  */
-class RedisCache(jedisPool: JedisPool, override val customClassloader: Option[ClassLoader] = None)(implicit val execContext: ExecutionContext = ExecutionContext.global)
+class RedisCache(val jedisPool: JedisPool, override val customClassloader: Option[ClassLoader] = None)(implicit val execContext: ExecutionContext = ExecutionContext.global)
     extends RedisCacheBase {
+
+  type JClient = Jedis
 
   override def removeAll() = Future {
     blocking {
-      withJedisCommands { jedis =>
-        val jedis = jedisPool.getResource()
-        try {
-          jedis.flushDB()
-        } finally {
-          jedis.close()
-        }
+      val jedis = jedisPool.getResource()
+      try {
+        jedis.flushDB()
+      } finally {
+        jedis.close()
       }
-    }
-  }
-
-  override def close(): Unit = {
-    jedisPool.close()
-  }
-
-  override def withJedisCommands[T](f: BinaryJedisCommands => T): T = {
-    val jedis = jedisPool.getResource()
-    try {
-      f(jedis)
-    } finally {
-      jedis.close()
     }
   }
 

--- a/redis/src/main/scala/scalacache/redis/RedisCacheBase.scala
+++ b/redis/src/main/scala/scalacache/redis/RedisCacheBase.scala
@@ -1,0 +1,78 @@
+package scalacache.redis
+
+import redis.clients.jedis._
+import scala.concurrent.{ ExecutionContext, Future, blocking }
+import scalacache.{ LoggingSupport, Cache }
+import scala.concurrent.duration._
+import com.typesafe.scalalogging.StrictLogging
+
+/**
+ * Contains implementations of all methods that can be implemented independent of the type of Redis client.
+ */
+trait RedisCacheBase
+    extends Cache
+    with RedisSerialization
+    with LoggingSupport
+    with StrictLogging {
+
+  import StringEnrichment.StringWithUtf8Bytes
+
+  implicit val execContext: ExecutionContext
+
+  protected def withJedisCommands[T](f: BinaryJedisCommands => T): T
+
+  /**
+   * Get the value corresponding to the given key from the cache
+   * @param key cache key
+   * @tparam V the type of the corresponding value
+   * @return the value, if there is one
+   */
+  final override def get[V](key: String) = Future {
+    blocking {
+      withJedisCommands { jedis =>
+        val resultBytes = Option(jedis.get(key.utf8bytes))
+        val result = resultBytes.map(deserialize[V])
+        logCacheHitOrMiss(key, result)
+        result
+      }
+    }
+  }
+
+  /**
+   * Insert the given key-value pair into the cache, with an optional Time To Live.
+   * @param key cache key
+   * @param value corresponding value
+   * @param ttl Time To Live
+   * @tparam V the type of the corresponding value
+   */
+  final override def put[V](key: String, value: V, ttl: Option[Duration]) = Future {
+    blocking {
+      withJedisCommands { jedis =>
+        val keyBytes = key.utf8bytes
+        val valueBytes = serialize(value)
+        ttl match {
+          case None => jedis.set(keyBytes, valueBytes)
+          case Some(Duration.Zero) => jedis.set(keyBytes, valueBytes)
+          case Some(d) if d < 1.second =>
+            logger.warn("Because Redis (pre 2.6.12) does not support sub-second expiry, TTL of $d will be rounded up to 1 second")
+            jedis.setex(keyBytes, 1, valueBytes)
+          case Some(d) => jedis.setex(keyBytes, d.toSeconds.toInt, valueBytes)
+        }
+      }
+    }
+  }
+
+  /**
+   * Remove the given key and its associated value from the cache, if it exists.
+   * If the key is not in the cache, do nothing.
+   * @param key cache key
+   */
+  final override def remove(key: String) = Future {
+    blocking {
+      withJedisCommands { jedis =>
+        jedis.del(key.utf8bytes)
+      }
+    }
+  }
+
+}

--- a/redis/src/main/scala/scalacache/redis/SentinelRedisCache.scala
+++ b/redis/src/main/scala/scalacache/redis/SentinelRedisCache.scala
@@ -1,0 +1,61 @@
+package scalacache.redis
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig
+import redis.clients.jedis._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ ExecutionContext, Future, blocking }
+
+class SentinelRedisCache(val jedisPool: JedisSentinelPool, override val customClassloader: Option[ClassLoader] = None)(implicit val execContext: ExecutionContext = ExecutionContext.global)
+    extends RedisCacheBase {
+
+  type JClient = Jedis
+
+  override def removeAll() = Future {
+    blocking {
+      val jedis = jedisPool.getResource()
+      try {
+        jedis.flushDB()
+      } finally {
+        jedis.close()
+      }
+    }
+  }
+
+}
+
+object SentinelRedisCache {
+
+  /**
+   * Create a `SentinelRedisCache` that uses a `JedisSentinelPool` with a default pool config.
+   *
+   * @param clusterName Name of the redis cluster
+   * @param sentinels set of sentinels in format [host1:port, host2:port]
+   * @param password password of the cluster
+   */
+  def apply(clusterName: String, sentinels: Set[String], password: String): SentinelRedisCache =
+    apply(new JedisSentinelPool(clusterName, sentinels.asJava, new GenericObjectPoolConfig, password))
+
+  /**
+   * Create a `SentinelRedisCache` that uses a `JedisSentinelPool` with a custom pool config.
+   *
+   * @param clusterName Name of the redis cluster
+   * @param sentinels set of sentinels in format [host1:port, host2:port]
+   * @param password password of the cluster
+   * @param poolConfig config of the underlying pool
+   */
+  def apply(clusterName: String, sentinels: Set[String], poolConfig: GenericObjectPoolConfig, password: String): SentinelRedisCache =
+    apply(new JedisSentinelPool(clusterName, sentinels.asJava, poolConfig, password))
+
+  /**
+   * Create a `SentinelRedisCache` that uses the given JedisSentinelPool
+   *
+   * @param jedisSentinelPool a JedisSentinelPool
+   * @param customClassloader a classloader to use when deserializing objects from the cache.
+   *                          If you are using Play, you should pass in `app.classloader`.
+   */
+  def apply(jedisSentinelPool: JedisSentinelPool, customClassloader: Option[ClassLoader] = None): SentinelRedisCache =
+    new SentinelRedisCache(jedisSentinelPool, customClassloader)
+
+}
+

--- a/redis/src/main/scala/scalacache/redis/ShardedRedisCache.scala
+++ b/redis/src/main/scala/scalacache/redis/ShardedRedisCache.scala
@@ -4,8 +4,10 @@ import redis.clients.jedis._
 import scala.concurrent.{ Future, ExecutionContext, blocking }
 import scala.collection.JavaConverters._
 
-class ShardedRedisCache(jedisPool: ShardedJedisPool, override val customClassloader: Option[ClassLoader] = None)(implicit val execContext: ExecutionContext = ExecutionContext.global)
+class ShardedRedisCache(val jedisPool: ShardedJedisPool, override val customClassloader: Option[ClassLoader] = None)(implicit val execContext: ExecutionContext = ExecutionContext.global)
     extends RedisCacheBase {
+
+  type JClient = ShardedJedis
 
   override def removeAll() = Future {
     blocking {
@@ -15,19 +17,6 @@ class ShardedRedisCache(jedisPool: ShardedJedisPool, override val customClassloa
       } finally {
         jedis.close()
       }
-    }
-  }
-
-  override def close(): Unit = {
-    jedisPool.close()
-  }
-
-  override def withJedisCommands[T](f: BinaryJedisCommands => T): T = {
-    val jedis = jedisPool.getResource()
-    try {
-      f(jedis)
-    } finally {
-      jedis.close()
     }
   }
 

--- a/redis/src/main/scala/scalacache/redis/ShardedRedisCache.scala
+++ b/redis/src/main/scala/scalacache/redis/ShardedRedisCache.scala
@@ -1,0 +1,56 @@
+package scalacache.redis
+
+import redis.clients.jedis._
+import scala.concurrent.{ Future, ExecutionContext, blocking }
+import scala.collection.JavaConverters._
+
+class ShardedRedisCache(jedisPool: ShardedJedisPool, override val customClassloader: Option[ClassLoader] = None)(implicit val execContext: ExecutionContext = ExecutionContext.global)
+    extends RedisCacheBase {
+
+  override def removeAll() = Future {
+    blocking {
+      val jedis = jedisPool.getResource()
+      try {
+        jedis.getAllShards.asScala.foreach(_.flushDB())
+      } finally {
+        jedis.close()
+      }
+    }
+  }
+
+  override def close(): Unit = {
+    jedisPool.close()
+  }
+
+  override def withJedisCommands[T](f: BinaryJedisCommands => T): T = {
+    val jedis = jedisPool.getResource()
+    try {
+      f(jedis)
+    } finally {
+      jedis.close()
+    }
+  }
+
+}
+
+object ShardedRedisCache {
+
+  /**
+   * Create a sharded Redis client connecting to the given hosts and use it for caching
+   */
+  def apply(hosts: (String, Int)*): ShardedRedisCache = {
+    val shards = hosts.map { case (host, port) => new JedisShardInfo(host, port) }
+    val pool = new ShardedJedisPool(new JedisPoolConfig(), shards.asJava)
+    apply(pool)
+  }
+
+  /**
+   * Create a cache that uses the given ShardedJedis client pool
+   * @param jedisPool a ShardedJedis pool
+   * @param customClassloader a classloader to use when deserializing objects from the cache.
+   *                          If you are using Play, you should pass in `app.classloader`.
+   */
+  def apply(jedisPool: ShardedJedisPool, customClassloader: Option[ClassLoader] = None): ShardedRedisCache =
+    new ShardedRedisCache(jedisPool, customClassloader)
+
+}

--- a/redis/src/main/scala/scalacache/redis/StringEnrichment.scala
+++ b/redis/src/main/scala/scalacache/redis/StringEnrichment.scala
@@ -1,0 +1,16 @@
+package scalacache.redis
+
+import java.nio.charset.Charset
+
+object StringEnrichment {
+
+  private val utf8 = Charset.forName("UTF-8")
+
+  /**
+   * Enrichment class to convert String to UTF-8 byte array
+   */
+  implicit class StringWithUtf8Bytes(val string: String) extends AnyVal {
+    def utf8bytes = string.getBytes(utf8)
+  }
+
+}

--- a/redis/src/test/scala/scalacache/redis/RedisCacheSpec.scala
+++ b/redis/src/test/scala/scalacache/redis/RedisCacheSpec.scala
@@ -1,133 +1,21 @@
 package scalacache.redis
 
-import org.scalatest.{ BeforeAndAfter, Matchers, FlatSpec }
-import scala.concurrent.duration._
-import org.scalatest.concurrent.{ ScalaFutures, Eventually, IntegrationPatience }
-import org.scalatest.time.{ Span, Seconds }
+import redis.clients.jedis._
 
 import scala.language.postfixOps
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+import scalacache.Cache
 
 class RedisCacheSpec
-    extends FlatSpec
-    with Matchers
-    with Eventually
-    with BeforeAndAfter
-    with RedisSerialization
-    with ScalaFutures
-    with IntegrationPatience
+    extends RedisCacheSpecBase
     with RedisTestUtil {
 
-  assumingRedisIsRunning { (pool, client) =>
+  type JClient = Jedis
+  type JPool = JedisPool
 
-    val cache = RedisCache(pool)
+  def withJedis(tests: (JPool, JClient) => Unit): Unit = assumingRedisIsRunning _
 
-    before {
-      client.flushDB()
-    }
+  def constructCache(pool: JPool): Cache = RedisCache(pool)
 
-    behavior of "get"
-
-    it should "return the value stored in Redis" in {
-      client.set(bytes("key1"), serialize(123))
-      whenReady(cache.get("key1")) { _ should be(Some(123)) }
-    }
-
-    it should "return None if the given key does not exist in the underlying cache" in {
-      whenReady(cache.get("non-existent-key")) { _ should be(None) }
-    }
-
-    behavior of "put"
-
-    it should "store the given key-value pair in the underlying cache" in {
-      whenReady(cache.put("key2", 123, None)) { _ =>
-        deserialize[Int](client.get(bytes("key2"))) should be(123)
-      }
-    }
-
-    behavior of "put with TTL"
-
-    it should "store the given key-value pair in the underlying cache" in {
-      whenReady(cache.put("key3", 123, Some(1 second))) { _ =>
-        deserialize[Int](client.get(bytes("key3"))) should be(123)
-
-        // Should expire after 1 second
-        eventually(timeout(Span(2, Seconds))) {
-          client.get(bytes("key3")) should be(null)
-        }
-      }
-    }
-
-    behavior of "put with TTL of zero"
-
-    it should "store the given key-value pair in the underlying cache with no expiry" in {
-      whenReady(cache.put("key4", 123, Some(Duration.Zero))) { _ =>
-        deserialize[Int](client.get(bytes("key4"))) should be(123)
-        client.ttl("key4") should be(-1L)
-      }
-    }
-
-    behavior of "put with TTL of less than 1 second"
-
-    it should "store the given key-value pair in the underlying cache" in {
-      whenReady(cache.put("key5", 123, Some(100 milliseconds))) { _ =>
-        deserialize[Int](client.get(bytes("key5"))) should be(123)
-        client.pttl("key5").toLong should be > 0L
-
-        // Should expire after 1 second
-        eventually(timeout(Span(2, Seconds))) {
-          client.get("key5") should be(null)
-        }
-      }
-    }
-
-    behavior of "caching with serialization"
-
-    def roundTrip[V](key: String, value: V): Future[Option[V]] = {
-      cache.put(key, value, None).flatMap(_ => cache.get(key))
-    }
-
-    it should "round-trip a String" in {
-      whenReady(roundTrip("string", "hello")) { _ should be(Some("hello")) }
-    }
-
-    it should "round-trip a byte array" in {
-      whenReady(roundTrip("bytearray", bytes("world"))) { result =>
-        new String(result.get, "UTF-8") should be("world")
-      }
-    }
-
-    it should "round-trip an Int" in {
-      whenReady(roundTrip("int", 345)) { _ should be(Some(345)) }
-    }
-
-    it should "round-trip a Double" in {
-      whenReady(roundTrip("double", 1.23)) { _ should be(Some(1.23)) }
-    }
-
-    it should "round-trip a Long" in {
-      whenReady(roundTrip("long", 3456L)) { _ should be(Some(3456L)) }
-    }
-
-    it should "round-trip a Serializable case class" in {
-      val cc = CaseClass(123, "wow")
-      whenReady(roundTrip("caseclass", cc)) { _ should be(Some(cc)) }
-    }
-
-    behavior of "remove"
-
-    it should "delete the given key and its value from the underlying cache" in {
-      client.set(bytes("key1"), serialize(123))
-      deserialize[Int](client.get(bytes("key1"))) should be(123)
-
-      whenReady(cache.remove("key1")) { _ =>
-        client.get("key1") should be(null)
-      }
-    }
-
-  }
-
-  def bytes(s: String) = s.getBytes("utf-8")
+  def flushRedis(client: JClient): Unit = client.flushDB()
 
 }

--- a/redis/src/test/scala/scalacache/redis/RedisCacheSpec.scala
+++ b/redis/src/test/scala/scalacache/redis/RedisCacheSpec.scala
@@ -12,10 +12,12 @@ class RedisCacheSpec
   type JClient = Jedis
   type JPool = JedisPool
 
-  def withJedis(tests: (JPool, JClient) => Unit): Unit = assumingRedisIsRunning _
+  val withJedis = assumingRedisIsRunning _
 
   def constructCache(pool: JPool): Cache = RedisCache(pool)
 
   def flushRedis(client: JClient): Unit = client.flushDB()
+
+  runTestsIfPossible()
 
 }

--- a/redis/src/test/scala/scalacache/redis/RedisCacheSpecBase.scala
+++ b/redis/src/test/scala/scalacache/redis/RedisCacheSpecBase.scala
@@ -23,115 +23,119 @@ trait RedisCacheSpecBase
   type JPool
   type JClient <: JedisCommands with BinaryJedisCommands
 
-  def withJedis(tests: (JPool, JClient) => Unit): Unit
+  def withJedis: ((JPool, JClient) => Unit) => Unit
   def constructCache(pool: JPool): Cache
   def flushRedis(client: JClient): Unit
 
-  withJedis { (pool, client) =>
+  def runTestsIfPossible() = {
 
-    val cache = constructCache(pool)
+    withJedis { (pool, client) =>
 
-    before {
-      flushRedis(client)
-    }
+      val cache = constructCache(pool)
 
-    behavior of "get"
-
-    it should "return the value stored in Redis" in {
-      client.set(bytes("key1"), serialize(123))
-      whenReady(cache.get("key1")) { _ should be(Some(123)) }
-    }
-
-    it should "return None if the given key does not exist in the underlying cache" in {
-      whenReady(cache.get("non-existent-key")) { _ should be(None) }
-    }
-
-    behavior of "put"
-
-    it should "store the given key-value pair in the underlying cache" in {
-      whenReady(cache.put("key2", 123, None)) { _ =>
-        deserialize[Int](client.get(bytes("key2"))) should be(123)
+      before {
+        flushRedis(client)
       }
-    }
 
-    behavior of "put with TTL"
+      behavior of "get"
 
-    it should "store the given key-value pair in the underlying cache" in {
-      whenReady(cache.put("key3", 123, Some(1 second))) { _ =>
-        deserialize[Int](client.get(bytes("key3"))) should be(123)
+      it should "return the value stored in Redis" in {
+        client.set(bytes("key1"), serialize(123))
+        whenReady(cache.get("key1")) { _ should be(Some(123)) }
+      }
 
-        // Should expire after 1 second
-        eventually(timeout(Span(2, Seconds))) {
-          client.get(bytes("key3")) should be(null)
+      it should "return None if the given key does not exist in the underlying cache" in {
+        whenReady(cache.get("non-existent-key")) { _ should be(None) }
+      }
+
+      behavior of "put"
+
+      it should "store the given key-value pair in the underlying cache" in {
+        whenReady(cache.put("key2", 123, None)) { _ =>
+          deserialize[Int](client.get(bytes("key2"))) should be(123)
         }
       }
-    }
 
-    behavior of "put with TTL of zero"
+      behavior of "put with TTL"
 
-    it should "store the given key-value pair in the underlying cache with no expiry" in {
-      whenReady(cache.put("key4", 123, Some(Duration.Zero))) { _ =>
-        deserialize[Int](client.get(bytes("key4"))) should be(123)
-        client.ttl(bytes("key4")) should be(-1L)
-      }
-    }
+      it should "store the given key-value pair in the underlying cache" in {
+        whenReady(cache.put("key3", 123, Some(1 second))) { _ =>
+          deserialize[Int](client.get(bytes("key3"))) should be(123)
 
-    behavior of "put with TTL of less than 1 second"
-
-    it should "store the given key-value pair in the underlying cache" in {
-      whenReady(cache.put("key5", 123, Some(100 milliseconds))) { _ =>
-        deserialize[Int](client.get(bytes("key5"))) should be(123)
-        client.pttl("key5").toLong should be > 0L
-
-        // Should expire after 1 second
-        eventually(timeout(Span(2, Seconds))) {
-          client.get(bytes("key5")) should be(null)
+          // Should expire after 1 second
+          eventually(timeout(Span(2, Seconds))) {
+            client.get(bytes("key3")) should be(null)
+          }
         }
       }
-    }
 
-    behavior of "caching with serialization"
+      behavior of "put with TTL of zero"
 
-    def roundTrip[V](key: String, value: V): Future[Option[V]] = {
-      cache.put(key, value, None).flatMap(_ => cache.get(key))
-    }
-
-    it should "round-trip a String" in {
-      whenReady(roundTrip("string", "hello")) { _ should be(Some("hello")) }
-    }
-
-    it should "round-trip a byte array" in {
-      whenReady(roundTrip("bytearray", bytes("world"))) { result =>
-        new String(result.get, "UTF-8") should be("world")
+      it should "store the given key-value pair in the underlying cache with no expiry" in {
+        whenReady(cache.put("key4", 123, Some(Duration.Zero))) { _ =>
+          deserialize[Int](client.get(bytes("key4"))) should be(123)
+          client.ttl(bytes("key4")) should be(-1L)
+        }
       }
-    }
 
-    it should "round-trip an Int" in {
-      whenReady(roundTrip("int", 345)) { _ should be(Some(345)) }
-    }
+      behavior of "put with TTL of less than 1 second"
 
-    it should "round-trip a Double" in {
-      whenReady(roundTrip("double", 1.23)) { _ should be(Some(1.23)) }
-    }
+      it should "store the given key-value pair in the underlying cache" in {
+        whenReady(cache.put("key5", 123, Some(100 milliseconds))) { _ =>
+          deserialize[Int](client.get(bytes("key5"))) should be(123)
+          client.pttl("key5").toLong should be > 0L
 
-    it should "round-trip a Long" in {
-      whenReady(roundTrip("long", 3456L)) { _ should be(Some(3456L)) }
-    }
-
-    it should "round-trip a Serializable case class" in {
-      val cc = CaseClass(123, "wow")
-      whenReady(roundTrip("caseclass", cc)) { _ should be(Some(cc)) }
-    }
-
-    behavior of "remove"
-
-    it should "delete the given key and its value from the underlying cache" in {
-      client.set(bytes("key1"), serialize(123))
-      deserialize[Int](client.get(bytes("key1"))) should be(123)
-
-      whenReady(cache.remove("key1")) { _ =>
-        client.get("key1") should be(null)
+          // Should expire after 1 second
+          eventually(timeout(Span(2, Seconds))) {
+            client.get(bytes("key5")) should be(null)
+          }
+        }
       }
+
+      behavior of "caching with serialization"
+
+      def roundTrip[V](key: String, value: V): Future[Option[V]] = {
+        cache.put(key, value, None).flatMap(_ => cache.get(key))
+      }
+
+      it should "round-trip a String" in {
+        whenReady(roundTrip("string", "hello")) { _ should be(Some("hello")) }
+      }
+
+      it should "round-trip a byte array" in {
+        whenReady(roundTrip("bytearray", bytes("world"))) { result =>
+          new String(result.get, "UTF-8") should be("world")
+        }
+      }
+
+      it should "round-trip an Int" in {
+        whenReady(roundTrip("int", 345)) { _ should be(Some(345)) }
+      }
+
+      it should "round-trip a Double" in {
+        whenReady(roundTrip("double", 1.23)) { _ should be(Some(1.23)) }
+      }
+
+      it should "round-trip a Long" in {
+        whenReady(roundTrip("long", 3456L)) { _ should be(Some(3456L)) }
+      }
+
+      it should "round-trip a Serializable case class" in {
+        val cc = CaseClass(123, "wow")
+        whenReady(roundTrip("caseclass", cc)) { _ should be(Some(cc)) }
+      }
+
+      behavior of "remove"
+
+      it should "delete the given key and its value from the underlying cache" in {
+        client.set(bytes("key1"), serialize(123))
+        deserialize[Int](client.get(bytes("key1"))) should be(123)
+
+        whenReady(cache.remove("key1")) { _ =>
+          client.get("key1") should be(null)
+        }
+      }
+
     }
 
   }

--- a/redis/src/test/scala/scalacache/redis/RedisCacheSpecBase.scala
+++ b/redis/src/test/scala/scalacache/redis/RedisCacheSpecBase.scala
@@ -1,0 +1,141 @@
+package scalacache.redis
+
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
+import org.scalatest.time.{Seconds, Span}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import redis.clients.jedis.{JedisCommands, BinaryJedisCommands}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scalacache.Cache
+
+trait RedisCacheSpecBase
+    extends FlatSpec
+    with Matchers
+    with Eventually
+    with BeforeAndAfter
+    with RedisSerialization
+    with ScalaFutures
+    with IntegrationPatience {
+
+  type JPool
+  type JClient <: JedisCommands with BinaryJedisCommands
+
+  def withJedis(tests: (JPool, JClient) => Unit): Unit
+  def constructCache(pool: JPool): Cache
+  def flushRedis(client: JClient): Unit
+
+  withJedis { (pool, client) =>
+
+    val cache = constructCache(pool)
+
+    before {
+      flushRedis(client)
+    }
+
+    behavior of "get"
+
+    it should "return the value stored in Redis" in {
+      client.set(bytes("key1"), serialize(123))
+      whenReady(cache.get("key1")) { _ should be(Some(123)) }
+    }
+
+    it should "return None if the given key does not exist in the underlying cache" in {
+      whenReady(cache.get("non-existent-key")) { _ should be(None) }
+    }
+
+    behavior of "put"
+
+    it should "store the given key-value pair in the underlying cache" in {
+      whenReady(cache.put("key2", 123, None)) { _ =>
+        deserialize[Int](client.get(bytes("key2"))) should be(123)
+      }
+    }
+
+    behavior of "put with TTL"
+
+    it should "store the given key-value pair in the underlying cache" in {
+      whenReady(cache.put("key3", 123, Some(1 second))) { _ =>
+        deserialize[Int](client.get(bytes("key3"))) should be(123)
+
+        // Should expire after 1 second
+        eventually(timeout(Span(2, Seconds))) {
+          client.get(bytes("key3")) should be(null)
+        }
+      }
+    }
+
+    behavior of "put with TTL of zero"
+
+    it should "store the given key-value pair in the underlying cache with no expiry" in {
+      whenReady(cache.put("key4", 123, Some(Duration.Zero))) { _ =>
+        deserialize[Int](client.get(bytes("key4"))) should be(123)
+        client.ttl(bytes("key4")) should be(-1L)
+      }
+    }
+
+    behavior of "put with TTL of less than 1 second"
+
+    it should "store the given key-value pair in the underlying cache" in {
+      whenReady(cache.put("key5", 123, Some(100 milliseconds))) { _ =>
+        deserialize[Int](client.get(bytes("key5"))) should be(123)
+        client.pttl("key5").toLong should be > 0L
+
+        // Should expire after 1 second
+        eventually(timeout(Span(2, Seconds))) {
+          client.get(bytes("key5")) should be(null)
+        }
+      }
+    }
+
+    behavior of "caching with serialization"
+
+    def roundTrip[V](key: String, value: V): Future[Option[V]] = {
+      cache.put(key, value, None).flatMap(_ => cache.get(key))
+    }
+
+    it should "round-trip a String" in {
+      whenReady(roundTrip("string", "hello")) { _ should be(Some("hello")) }
+    }
+
+    it should "round-trip a byte array" in {
+      whenReady(roundTrip("bytearray", bytes("world"))) { result =>
+        new String(result.get, "UTF-8") should be("world")
+      }
+    }
+
+    it should "round-trip an Int" in {
+      whenReady(roundTrip("int", 345)) { _ should be(Some(345)) }
+    }
+
+    it should "round-trip a Double" in {
+      whenReady(roundTrip("double", 1.23)) { _ should be(Some(1.23)) }
+    }
+
+    it should "round-trip a Long" in {
+      whenReady(roundTrip("long", 3456L)) { _ should be(Some(3456L)) }
+    }
+
+    it should "round-trip a Serializable case class" in {
+      val cc = CaseClass(123, "wow")
+      whenReady(roundTrip("caseclass", cc)) { _ should be(Some(cc)) }
+    }
+
+    behavior of "remove"
+
+    it should "delete the given key and its value from the underlying cache" in {
+      client.set(bytes("key1"), serialize(123))
+      deserialize[Int](client.get(bytes("key1"))) should be(123)
+
+      whenReady(cache.remove("key1")) { _ =>
+        client.get("key1") should be(null)
+      }
+    }
+
+  }
+
+  def bytes(s: String) = s.getBytes("utf-8")
+
+}

--- a/redis/src/test/scala/scalacache/redis/RedisTestUtil.scala
+++ b/redis/src/test/scala/scalacache/redis/RedisTestUtil.scala
@@ -15,8 +15,7 @@ trait RedisTestUtil { self: Alerting =>
       (jedisPool, jedis)
     } match {
       case Failure(_) => alert("Skipping tests because Redis does not appear to be running on localhost.")
-      case Success((pool, client)) =>
-        f(pool, client)
+      case Success((pool, client)) => f(pool, client)
     }
   }
 

--- a/redis/src/test/scala/scalacache/redis/RedisTestUtil.scala
+++ b/redis/src/test/scala/scalacache/redis/RedisTestUtil.scala
@@ -1,7 +1,7 @@
 package scalacache.redis
 
 import org.scalatest.Alerting
-import redis.clients.jedis.{ JedisPool, Jedis }
+import redis.clients.jedis._
 
 import scala.util.{ Success, Failure, Try }
 

--- a/redis/src/test/scala/scalacache/redis/SentinelRedisCacheSpec.scala
+++ b/redis/src/test/scala/scalacache/redis/SentinelRedisCacheSpec.scala
@@ -1,0 +1,39 @@
+package scalacache.redis
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig
+import redis.clients.jedis._
+
+import scala.collection.JavaConverters._
+import scala.util.{ Failure, Success, Try }
+import scalacache.Cache
+
+class SentinelRedisCacheSpec extends RedisCacheSpecBase {
+
+  type JClient = Jedis
+  type JPool = JedisSentinelPool
+
+  val withJedis = assumingRedisSentinelIsRunning _
+
+  def constructCache(pool: JPool): Cache = SentinelRedisCache(pool)
+
+  def flushRedis(client: JClient): Unit = client.flushDB()
+
+  /**
+   * This assumes that Redis master with name "master" and password "master-local" is running,
+   * and a sentinel is also running with to monitor this master on port 26379.
+   */
+  def assumingRedisSentinelIsRunning(f: (JedisSentinelPool, Jedis) => Unit): Unit = {
+    Try {
+      val jedisPool = new JedisSentinelPool("master", Set("127.0.0.1:26379").asJava, new GenericObjectPoolConfig)
+      val jedis = jedisPool.getResource()
+      jedis.ping()
+      (jedisPool, jedis)
+    } match {
+      case Failure(_) => alert("Skipping tests because Redis master and sentinel does not appear to be running on localhost.")
+      case Success((pool, client)) => f(pool, client)
+    }
+  }
+
+  runTestsIfPossible()
+
+}

--- a/redis/src/test/scala/scalacache/redis/ShardedRedisCacheSpec.scala
+++ b/redis/src/test/scala/scalacache/redis/ShardedRedisCacheSpec.scala
@@ -30,8 +30,7 @@ class ShardedRedisCacheSpec extends RedisCacheSpecBase {
       (jedisPool, jedis)
     } match {
       case Failure(_) => alert("Skipping tests because it does not appear that multiple instances of Redis are running on localhost.")
-      case Success((pool, client)) =>
-        f(pool, client)
+      case Success((pool, client)) => f(pool, client)
     }
   }
 

--- a/redis/src/test/scala/scalacache/redis/ShardedRedisCacheSpec.scala
+++ b/redis/src/test/scala/scalacache/redis/ShardedRedisCacheSpec.scala
@@ -11,7 +11,7 @@ class ShardedRedisCacheSpec extends RedisCacheSpecBase {
   type JClient = ShardedJedis
   type JPool = ShardedJedisPool
 
-  def withJedis(tests: (JPool, JClient) => Unit): Unit = assumingMultipleRedisAreRunning _
+  val withJedis = assumingMultipleRedisAreRunning _
 
   def constructCache(pool: JPool): Cache = ShardedRedisCache(pool)
 
@@ -34,5 +34,7 @@ class ShardedRedisCacheSpec extends RedisCacheSpecBase {
         f(pool, client)
     }
   }
+
+  runTestsIfPossible()
 
 }

--- a/redis/src/test/scala/scalacache/redis/ShardedRedisCacheSpec.scala
+++ b/redis/src/test/scala/scalacache/redis/ShardedRedisCacheSpec.scala
@@ -1,0 +1,38 @@
+package scalacache.redis
+
+import redis.clients.jedis.{ JedisPoolConfig, JedisShardInfo, ShardedJedis, ShardedJedisPool }
+
+import scala.util.{ Success, Failure, Try }
+import scala.collection.JavaConverters._
+import scalacache.Cache
+
+class ShardedRedisCacheSpec extends RedisCacheSpecBase {
+
+  type JClient = ShardedJedis
+  type JPool = ShardedJedisPool
+
+  def withJedis(tests: (JPool, JClient) => Unit): Unit = assumingMultipleRedisAreRunning _
+
+  def constructCache(pool: JPool): Cache = ShardedRedisCache(pool)
+
+  def flushRedis(client: JClient): Unit = client.getAllShards.asScala.foreach(_.flushDB())
+
+  def assumingMultipleRedisAreRunning(f: (ShardedJedisPool, ShardedJedis) => Unit): Unit = {
+    Try {
+      val shard1 = new JedisShardInfo("localhost", 6379)
+      val shard2 = new JedisShardInfo("localhost", 6380)
+
+      val jedisPool = new ShardedJedisPool(new JedisPoolConfig(), java.util.Arrays.asList(shard1, shard2))
+      val jedis = jedisPool.getResource
+
+      jedis.getAllShards.asScala.foreach(_.ping())
+
+      (jedisPool, jedis)
+    } match {
+      case Failure(_) => alert("Skipping tests because it does not appear that multiple instances of Redis are running on localhost.")
+      case Success((pool, client)) =>
+        f(pool, client)
+    }
+  }
+
+}


### PR DESCRIPTION
Adds two new `Cache` implementations to `scalacache-redis`:

* `ShardedRedisCache` wraps a `ShardedJedisPool`
* `SentinelRedisCache` wraps a `JedisSentinelPool`

Also refactored both the implementation and the tests to share code between the 3 Redis implementations.

Also bump Jedis to 2.8.0.