### PR TITLE
Implement compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,18 @@ types, and provide an implementation for objects based on Java serialisation.
 
 ### Custom Codec
 
-If you want to use a custom `Codec` for your object of type `A`, simply implement an instance of `Codec[A]` and make sure it
+If you want to use a custom `Codec` for your object of type `A`, simply implement an instance of `Codec[A, Array[Byte]]` and make sure it
 is in scope at your `set`/`put` call site.
+
+### Compression of `Codec[A, Array[Byte]]`
+
+If you want to compress your serialised data before sending it to your cache, ScalaCache has a built-in `GZippingBinaryCodec[A]` mix-in
+trait that will automatically apply GZip  compression before sending it over the wire if the `Array[Byte]` representation is above a `sizeThreshold`. 
+It also takes care of properly decompressing data upon retrieval. To use it, simply extend your `Codec[A, Array[Byte] with GZippingBinaryCodec[A]` 
+**last** (it should be the right-most extended trait).
+
+Those who want to use GZip compression with standard Java serialisation can `import scalacache.serialization.GZippingJavaAnyBinaryCodec._` or
+provide an implicit `GZippingJavaAnyBinaryCodec` at the cache call site.
 
 ### Backwards compatibility
 

--- a/core/src/main/scala/scalacache/serialization/BaseCodecs.scala
+++ b/core/src/main/scala/scalacache/serialization/BaseCodecs.scala
@@ -8,8 +8,8 @@ package scalacache.serialization
 trait BaseCodecs {
 
   /**
-    * Noop Codec that does nothing when you just want to put stuff into in-memory cache representations
-    */
+   * Noop Codec that does nothing when you just want to put stuff into in-memory cache representations
+   */
   implicit def anyToNoSerialization[A] = new Codec[A, InMemoryRepr] {
     def serialize(value: A): InMemoryRepr = throw new RuntimeException("Cache using InMemoryRepr trying to serialize data")
     def deserialize(data: InMemoryRepr): A = throw new RuntimeException("Cache using InMemoryRepr trying to deserialize data")

--- a/core/src/main/scala/scalacache/serialization/GZippingJavaAnyBinaryCodec.scala
+++ b/core/src/main/scala/scalacache/serialization/GZippingJavaAnyBinaryCodec.scala
@@ -1,0 +1,17 @@
+package scalacache.serialization
+
+import java.io.Serializable
+import scala.reflect.ClassTag
+
+object GZippingJavaAnyBinaryCodec {
+
+  /**
+    * Compressing Java generic codec with a threshold of 16K
+    */
+  implicit def default[S <: Serializable](implicit ev: ClassTag[S]): GZippingJavaAnyBinaryCodec[S] = new GZippingJavaAnyBinaryCodec(CompressingCodec.DefaultSizeThreshold)(ev)
+
+}
+
+class GZippingJavaAnyBinaryCodec[S <: Serializable](override val sizeThreshold: Int)(implicit classTag: ClassTag[S])
+  extends JavaSerializationAnyCodec[S](classTag)
+    with GZippingBinaryCodec[S]

--- a/core/src/main/scala/scalacache/serialization/GenericCodecObjectInputStream.scala
+++ b/core/src/main/scala/scalacache/serialization/GenericCodecObjectInputStream.scala
@@ -1,0 +1,34 @@
+package scalacache.serialization
+
+import java.io.{ InputStream, ObjectInputStream, ObjectStreamClass }
+
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
+
+/**
+ * Object input stream which tries the thread local class loader.
+ *
+ * Thread Local class loader is used by SBT to avoid polluting system class loader when
+ * running different tasks.
+ *
+ * This allows deserialization of classes from sub-projects during something like
+ * Play's test/run modes.
+ */
+private[serialization] class GenericCodecObjectInputStream(classTag: ClassTag[_], in: InputStream)
+    extends ObjectInputStream(in) {
+
+  private def classTagClassLoader =
+    classTag.runtimeClass.getClassLoader
+  private def threadLocalClassLoader =
+    Thread.currentThread().getContextClassLoader
+
+  override protected def resolveClass(desc: ObjectStreamClass): Class[_] = {
+    try classTagClassLoader.loadClass(desc.getName) catch {
+      case NonFatal(_) =>
+        try super.resolveClass(desc) catch {
+          case NonFatal(_) =>
+            threadLocalClassLoader.loadClass(desc.getName)
+        }
+    }
+  }
+}

--- a/core/src/main/scala/scalacache/serialization/GzippingBinaryCodec.scala
+++ b/core/src/main/scala/scalacache/serialization/GzippingBinaryCodec.scala
@@ -1,0 +1,86 @@
+package scalacache.serialization
+
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
+import java.util.zip.{ GZIPInputStream, GZIPOutputStream }
+
+object CompressingCodec {
+
+  /**
+   * Default threshold for compression is is 16k
+   */
+  val DefaultSizeThreshold: Int = 16384
+
+  /**
+   * Headers aka magic numbers to let us know if something has been compressed or not
+   */
+  object Headers {
+    val Uncompressed: Byte = 0
+    val Gzipped: Byte = 1
+  }
+
+}
+
+/**
+ * Mixing this into any Codec will automatically GZip the resulting Byte Array when serialising and handle un-Gzipping when
+ * deserialising
+ */
+trait GZippingBinaryCodec[A] extends Codec[A, Array[Byte]] {
+
+  import CompressingCodec._
+
+  /**
+   * Size above which data will get compressed
+   */
+  protected def sizeThreshold: Int = CompressingCodec.DefaultSizeThreshold
+
+  abstract override def serialize(value: A): Array[Byte] = {
+    val serialised = super.serialize(value)
+    if (serialised.length > sizeThreshold) {
+      Headers.Gzipped +: compress(serialised)
+    } else {
+      Headers.Uncompressed +: serialised
+    }
+  }
+
+  abstract override def deserialize(data: Array[Byte]): A = {
+    val firstByte = data.headOption
+    firstByte match {
+      case Some(Headers.Uncompressed) => super.deserialize(data.tail)
+      case Some(Headers.Gzipped) => super.deserialize(decompress(data.tail))
+      case unexpected => throw new RuntimeException(s"Expected either ${Headers.Uncompressed} or ${Headers.Gzipped} but got $unexpected")
+    }
+  }
+
+  // Port of compress in SpyMemcached
+  private def compress(data: Array[Byte]): Array[Byte] = {
+    val byteOutputStream = new ByteArrayOutputStream()
+    val gzipOutputStream = new GZIPOutputStream(byteOutputStream)
+    try {
+      gzipOutputStream.write(data)
+    } finally {
+      gzipOutputStream.close()
+      byteOutputStream.close()
+    }
+    byteOutputStream.toByteArray
+  }
+
+  // Port of decompress in SpyMemcached
+  private def decompress(data: Array[Byte]): Array[Byte] = {
+    val bis = new ByteArrayInputStream(data)
+    val gis = new GZIPInputStream(bis)
+    val bos = new ByteArrayOutputStream
+    val buf = new Array[Byte](4 * 1024)
+    try {
+      var r = gis.read(buf)
+      while (r > 0) {
+        bos.write(buf, 0, r)
+        r = gis.read(buf)
+      }
+    } finally {
+      gis.close()
+      bis.close()
+      bos.close()
+    }
+    bos.toByteArray
+  }
+}

--- a/core/src/main/scala/scalacache/serialization/JavaSerializationCodec.scala
+++ b/core/src/main/scala/scalacache/serialization/JavaSerializationCodec.scala
@@ -11,67 +11,38 @@ import scala.util.control.NonFatal
   * Credit: Shade @ https://github.com/alexandru/shade/blob/master/src/main/scala/shade/memcached/Codec.scala
   */
 trait JavaSerializationCodec {
-
-  private[this] class GenericCodec[S <: Serializable](classTag: ClassTag[S]) extends Codec[S, Array[Byte]] {
-
-    def using[T <: Closeable, R](obj: T)(f: T => R): R =
-      try
-        f(obj)
-      finally
-        try obj.close() catch {
-          case NonFatal(_) => // does nothing
-        }
-
-    def serialize(value: S): Array[Byte] =
-      using (new ByteArrayOutputStream()) { buf =>
-        using (new ObjectOutputStream(buf)) { out =>
-          out.writeObject(value)
-          out.close()
-          buf.toByteArray
-        }
-      }
-
-    def deserialize(data: Array[Byte]): S =
-      using (new ByteArrayInputStream(data)) { buf =>
-        val in = new GenericCodecObjectInputStream(classTag, buf)
-        using (in) { inp =>
-          inp.readObject().asInstanceOf[S]
-        }
-      }
-  }
-
   /**
     * Uses plain Java serialization to deserialize objects
     */
   implicit def AnyRefBinaryCodec[S <: Serializable](implicit ev: ClassTag[S]): Codec[S, Array[Byte]] =
-    new GenericCodec[S](ev)
+    new JavaSerializationAnyCodec[S](ev)
 
 }
 
-/**
-  * Object input stream which tries the thread local class loader.
-  *
-  * Thread Local class loader is used by SBT to avoid polluting system class loader when
-  * running different tasks.
-  *
-  * This allows deserialization of classes from sub-projects during something like
-  * Play's test/run modes.
-  */
-class GenericCodecObjectInputStream(classTag: ClassTag[_], in: InputStream)
-  extends ObjectInputStream(in) {
+class JavaSerializationAnyCodec[S <: Serializable](classTag: ClassTag[S]) extends Codec[S, Array[Byte]] {
 
-  private def classTagClassLoader =
-    classTag.runtimeClass.getClassLoader
-  private def threadLocalClassLoader =
-    Thread.currentThread().getContextClassLoader
+  def using[T <: Closeable, R](obj: T)(f: T => R): R =
+    try
+      f(obj)
+    finally
+      try obj.close() catch {
+        case NonFatal(_) => // does nothing
+      }
 
-  override protected def resolveClass(desc: ObjectStreamClass): Class[_] = {
-    try classTagClassLoader.loadClass(desc.getName) catch {
-      case NonFatal(_) =>
-        try super.resolveClass(desc) catch {
-          case NonFatal(_) =>
-            threadLocalClassLoader.loadClass(desc.getName)
-        }
+  def serialize(value: S): Array[Byte] =
+    using (new ByteArrayOutputStream()) { buf =>
+      using (new ObjectOutputStream(buf)) { out =>
+        out.writeObject(value)
+        out.close()
+        buf.toByteArray
+      }
     }
-  }
+
+  def deserialize(data: Array[Byte]): S =
+    using (new ByteArrayInputStream(data)) { buf =>
+      val in = new GenericCodecObjectInputStream(classTag, buf)
+      using (in) { inp =>
+        inp.readObject().asInstanceOf[S]
+      }
+    }
 }

--- a/core/src/test/scala/scalacache/serialization/GZippingJavaAnyBinaryCodecSpec.scala
+++ b/core/src/test/scala/scalacache/serialization/GZippingJavaAnyBinaryCodecSpec.scala
@@ -1,0 +1,28 @@
+package scalacache.serialization
+
+import org.scalatest.{ FlatSpec, Matchers }
+
+import scala.util.Random
+
+class GZippingJavaAnyBinaryCodecSpec extends FlatSpec with Matchers {
+
+  import GZippingJavaAnyBinaryCodec._
+  val codec = implicitly[Codec[Phone, Array[Byte]]]
+
+  it should "work without compression" in {
+    val phone = Phone(1, "abc")
+    val serialised = codec.serialize(phone)
+    serialised.head shouldBe CompressingCodec.Headers.Uncompressed
+    val deserialised = codec.deserialize(serialised)
+    deserialised shouldBe phone
+  }
+
+  it should "work with compression" in {
+    val phone = Phone(1, Random.alphanumeric.take(CompressingCodec.DefaultSizeThreshold + 1).mkString)
+    val serialised = codec.serialize(phone)
+    serialised.head shouldBe CompressingCodec.Headers.Gzipped
+    val deserialised = codec.deserialize(serialised)
+    deserialised shouldBe phone
+  }
+
+}


### PR DESCRIPTION
Adds support for compression/decompression of serialised data. 

Current implementation is as a mixin to any `Codec` and uses GZip as you mentioned in #86. Another approach would be to add a field on caches that send data over the wire like Redis or Memcached that does something similar.

Changes:
- Refactor some old code to allow for extension
- Add a GzippingCodec that can be used to add Gzipping on any Codec
- Add tests for CompressionJavaCodec
- Misc refactoring