### PR TITLE
Add a dummy codec for non-Serializable classes

### DIFF
--- a/caffeine/src/test/scala/foo/Issue90Spec.scala
+++ b/caffeine/src/test/scala/foo/Issue90Spec.scala
@@ -1,0 +1,30 @@
+package foo
+
+import org.scalatest._
+
+/**
+ * Replicating the issue reported in https://github.com/cb372/scalacache/issues/90
+ */
+class Issue90Spec extends FlatSpec with Matchers {
+
+  "Issue 90" should "be fixed" in {
+    import scalacache._
+    import caffeine._
+    import scala.concurrent.duration._
+
+    implicit val scalaCache = ScalaCache(CaffeineCache())
+
+    def baz(): Seq[foo.Bar] = Seq(
+      Bar(1, "one"),
+      Bar(2, "two")
+    )
+    val ttl = 1.second
+
+    """
+    def logic(): Seq[foo.Bar] = sync.cachingWithTTL("the-key")(ttl)(baz())
+    """ should compile
+  }
+
+}
+
+case class Bar(a: Int, b: String)

--- a/core/src/main/scala/scalacache/serialization/JavaSerializationCodec.scala
+++ b/core/src/main/scala/scalacache/serialization/JavaSerializationCodec.scala
@@ -6,11 +6,34 @@ import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
 /**
+  * The world's least useful codec.
+  * Just throws a runtime exception if you try to use it.
+  *
+  * Only exists so that we can provide codecs for any class <: AnyRef,
+  * so that people don't run into "codec missing" issues when using in-memory cache impls e.g. Caffeine.
+  *
+  * See https://github.com/cb372/scalacache/issues/90
+  */
+trait AnyRefDummyLowPriorityCodec {
+
+  implicit def AnyRefBinaryCodec[S <: AnyRef](implicit classTag: ClassTag[S]) = new Codec[S] {
+
+    def serialize(value: S): Array[Byte] =
+      sys.error(s"Sorry, I don't know how to serialize an instance of class ${classTag.runtimeClass.getName}. Please provide a custom Codec.")
+
+    def deserialize(data: Array[Byte]): S =
+      sys.error(s"Sorry, I don't know how to deserialize an instance of class ${classTag.runtimeClass.getName}. Please provide a custom Codec.")
+
+  }
+
+}
+
+/**
   * Holds a Java-serialisation-based Codec[Object <: Serializable] instance
   *
   * Credit: Shade @ https://github.com/alexandru/shade/blob/master/src/main/scala/shade/memcached/Codec.scala
   */
-trait JavaSerializationCodec {
+trait JavaSerializationCodec extends AnyRefDummyLowPriorityCodec {
 
   private[this] class GenericCodec[S <: Serializable](classTag: ClassTag[S]) extends Codec[S] {
 
@@ -43,7 +66,7 @@ trait JavaSerializationCodec {
   /**
     * Uses plain Java serialization to deserialize objects
     */
-  implicit def AnyRefBinaryCodec[S <: Serializable](implicit ev: ClassTag[S]): Codec[S] =
+  implicit def SerializableBinaryCodec[S <: Serializable](implicit ev: ClassTag[S]): Codec[S] =
     new GenericCodec[S](ev)
 
 }


### PR DESCRIPTION
Fixes #90

The tradeoff is that it's now possible to attempt to serialise a non-Serializable object using Redis/Memcached and get a runtime exception. But that was also true with the legacy serialisation.