### PR TITLE
#90 and #91: Add Repr to Codec

### DIFF
--- a/caffeine/src/test/scala/foo/Issue90Spec.scala
+++ b/caffeine/src/test/scala/foo/Issue90Spec.scala
@@ -1,0 +1,30 @@
+package foo
+
+import org.scalatest._
+
+/**
+ * Replicating the issue reported in https://github.com/cb372/scalacache/issues/90
+ */
+class Issue90Spec extends FlatSpec with Matchers {
+
+  "Issue 90" should "be fixed" in {
+    import scalacache._
+    import caffeine._
+    import scala.concurrent.duration._
+
+    implicit val scalaCache = ScalaCache(CaffeineCache())
+
+    def baz(): Seq[foo.Bar] = Seq(
+      Bar(1, "one"),
+      Bar(2, "two")
+    )
+    val ttl = 1.second
+
+    """
+    def logic(): Seq[foo.Bar] = sync.cachingWithTTL("the-key")(ttl)(baz())
+    """ should compile
+  }
+
+}
+
+case class Bar(a: Int, b: String)

--- a/core/src/main/scala/scalacache/Cache.scala
+++ b/core/src/main/scala/scalacache/Cache.scala
@@ -4,7 +4,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scalacache.serialization.Codec
 
-trait Cache {
+trait Cache[Repr] {
 
   /**
    * Get the value corresponding to the given key from the cache
@@ -13,7 +13,7 @@ trait Cache {
    * @tparam V the type of the corresponding value
    * @return the value, if there is one
    */
-  def get[V](key: String)(implicit codec: Codec[V]): Future[Option[V]]
+  def get[V](key: String)(implicit codec: Codec[V, Repr]): Future[Option[V]]
 
   /**
    * Insert the given key-value pair into the cache, with an optional Time To Live.
@@ -23,7 +23,7 @@ trait Cache {
    * @param ttl Time To Live
    * @tparam V the type of the corresponding value
    */
-  def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V]): Future[Unit]
+  def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, Repr]): Future[Unit]
 
   /**
    * Remove the given key and its associated value from the cache, if it exists.

--- a/core/src/main/scala/scalacache/ScalaCache.scala
+++ b/core/src/main/scala/scalacache/ScalaCache.scala
@@ -7,8 +7,8 @@ import scalacache.memoization.MemoizationConfig
  * @param cache The cache itself
  * @param memoization Configuration related to method memoization
  */
-case class ScalaCache(
-  cache: Cache,
+case class ScalaCache[Repr](
+  cache: Cache[Repr],
   cacheConfig: CacheConfig = CacheConfig(),
   keyBuilder: CacheKeyBuilder = DefaultCacheKeyBuilder,
   memoization: MemoizationConfig = MemoizationConfig())

--- a/core/src/main/scala/scalacache/memoization/Macros.scala
+++ b/core/src/main/scala/scalacache/memoization/Macros.scala
@@ -14,43 +14,43 @@ class Macros(val c: blackbox.Context) {
   We get weird macro compilation errors if we write `f: c.Expr[Future[A]]`, so we'll cheat and just make it a `c.Tree`.
   I think this is a macros bug.
    */
-  def memoizeImpl[A: c.WeakTypeTag](f: c.Tree)(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags], ec: c.Expr[ExecutionContext], codec: c.Expr[Codec[A]]): Tree = {
+  def memoizeImpl[A: c.WeakTypeTag, Repr: c.WeakTypeTag](f: c.Tree)(scalaCache: c.Expr[ScalaCache[Repr]], flags: c.Expr[Flags], ec: c.Expr[ExecutionContext], codec: c.Expr[Codec[A, Repr]]): Tree = {
     commonMacroImpl(scalaCache, { keyName =>
       q"""_root_.scalacache.caching($keyName)($f)($scalaCache, $flags, $ec, $codec)"""
     })
   }
 
-  def memoizeImplWithTTL[A: c.WeakTypeTag](ttl: c.Expr[Duration])(f: c.Tree)(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags], ec: c.Expr[ExecutionContext], codec: c.Expr[Codec[A]]): Tree = {
+  def memoizeImplWithTTL[A: c.WeakTypeTag, Repr: c.WeakTypeTag](ttl: c.Expr[Duration])(f: c.Tree)(scalaCache: c.Expr[ScalaCache[Repr]], flags: c.Expr[Flags], ec: c.Expr[ExecutionContext], codec: c.Expr[Codec[A, Repr]]): Tree = {
     commonMacroImpl(scalaCache, { keyName =>
       q"""_root_.scalacache.cachingWithTTL($keyName)($ttl)($f)($scalaCache, $flags, $ec, $codec)"""
     })
   }
 
-  def memoizeImplWithOptionalTTL[A: c.WeakTypeTag](optionalTtl: c.Expr[Option[Duration]])(f: c.Tree)(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags], ec: c.Expr[ExecutionContext], codec: c.Expr[Codec[A]]): Tree = {
+  def memoizeImplWithOptionalTTL[A: c.WeakTypeTag, Repr: c.WeakTypeTag](optionalTtl: c.Expr[Option[Duration]])(f: c.Tree)(scalaCache: c.Expr[ScalaCache[Repr]], flags: c.Expr[Flags], ec: c.Expr[ExecutionContext], codec: c.Expr[Codec[A, Repr]]): Tree = {
     commonMacroImpl(scalaCache, { keyName =>
       q"""_root_.scalacache.cachingWithOptionalTTL($keyName)($optionalTtl)($f)($scalaCache, $flags, $ec, $codec)"""
     })
   }
 
-  def memoizeSyncImpl[A: c.WeakTypeTag](f: c.Expr[A])(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags], codec: c.Expr[Codec[A]]): Tree = {
+  def memoizeSyncImpl[A: c.WeakTypeTag, Repr: c.WeakTypeTag](f: c.Expr[A])(scalaCache: c.Expr[ScalaCache[Repr]], flags: c.Expr[Flags], codec: c.Expr[Codec[A, Repr]]): Tree = {
     commonMacroImpl(scalaCache, { keyName =>
       q"""_root_.scalacache.sync.caching($keyName)($f)($scalaCache, $flags, $codec)"""
     })
   }
 
-  def memoizeSyncImplWithTTL[A: c.WeakTypeTag](ttl: c.Expr[Duration])(f: c.Expr[A])(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags], codec: c.Expr[Codec[A]]): Tree = {
+  def memoizeSyncImplWithTTL[A: c.WeakTypeTag, Repr: c.WeakTypeTag](ttl: c.Expr[Duration])(f: c.Expr[A])(scalaCache: c.Expr[ScalaCache[Repr]], flags: c.Expr[Flags], codec: c.Expr[Codec[A, Repr]]): Tree = {
     commonMacroImpl(scalaCache, { keyName =>
       q"""_root_.scalacache.sync.cachingWithTTL($keyName)($ttl)($f)($scalaCache, $flags, $codec)"""
     })
   }
 
-  def memoizeSyncImplWithOptionalTTL[A: c.WeakTypeTag](optionalTtl: c.Expr[Option[Duration]])(f: c.Expr[A])(scalaCache: c.Expr[ScalaCache], flags: c.Expr[Flags], codec: c.Expr[Codec[A]]): Tree = {
+  def memoizeSyncImplWithOptionalTTL[A: c.WeakTypeTag, Repr: c.WeakTypeTag](optionalTtl: c.Expr[Option[Duration]])(f: c.Expr[A])(scalaCache: c.Expr[ScalaCache[Repr]], flags: c.Expr[Flags], codec: c.Expr[Codec[A, Repr]]): Tree = {
     commonMacroImpl(scalaCache, { keyName =>
       q"""_root_.scalacache.sync.cachingWithOptionalTTL($keyName)($optionalTtl)($f)($scalaCache, $flags, $codec)"""
     })
   }
 
-  private def commonMacroImpl[A: c.WeakTypeTag](scalaCache: c.Expr[ScalaCache], keyNameToCachingCall: (c.TermName) => c.Tree): Tree = {
+  private def commonMacroImpl[A: c.WeakTypeTag, Repr: c.WeakTypeTag](scalaCache: c.Expr[ScalaCache[Repr]], keyNameToCachingCall: (c.TermName) => c.Tree): Tree = {
 
     val enclosingMethodSymbol = getMethodSymbol()
     val classSymbol = getClassSymbol()

--- a/core/src/main/scala/scalacache/memoization/package.scala
+++ b/core/src/main/scala/scalacache/memoization/package.scala
@@ -31,7 +31,7 @@ package object memoization {
    * @tparam A type of the value to be cached
    * @return a Future of the result, either retrieved from the cache or calculated by executing the function `f`
    */
-  def memoize[A](f: => Future[A])(implicit scalaCache: ScalaCache, flags: Flags, ec: ExecutionContext, codec: Codec[A]): Future[A] = macro Macros.memoizeImpl[A]
+  def memoize[A, Repr](f: => Future[A])(implicit scalaCache: ScalaCache[Repr], flags: Flags, ec: ExecutionContext, codec: Codec[A, Repr]): Future[A] = macro Macros.memoizeImpl[A, Repr]
 
   /**
    * Perform the given operation and memoize its result to a cache before returning it.
@@ -56,7 +56,7 @@ package object memoization {
    * @tparam A type of the value to be cached
    * @return a Future of the result, either retrieved from the cache or calculated by executing the function `f`
    */
-  def memoize[A](ttl: Duration)(f: => Future[A])(implicit scalaCache: ScalaCache, flags: Flags, ec: ExecutionContext, codec: Codec[A]): Future[A] = macro Macros.memoizeImplWithTTL[A]
+  def memoize[A, Repr](ttl: Duration)(f: => Future[A])(implicit scalaCache: ScalaCache[Repr], flags: Flags, ec: ExecutionContext, codec: Codec[A, Repr]): Future[A] = macro Macros.memoizeImplWithTTL[A, Repr]
 
   /**
    * Perform the given operation and memoize its result to a cache before returning it.
@@ -80,7 +80,7 @@ package object memoization {
    * @tparam A type of the value to be cached
    * @return the result, either retrieved from the cache or calculated by executing the function `f`
    */
-  def memoize[A](optionalTtl: Option[Duration])(f: => Future[A])(implicit scalaCache: ScalaCache, flags: Flags, ec: ExecutionContext, codec: Codec[A]): Future[A] = macro Macros.memoizeImplWithOptionalTTL[A]
+  def memoize[A, Repr](optionalTtl: Option[Duration])(f: => Future[A])(implicit scalaCache: ScalaCache[Repr], flags: Flags, ec: ExecutionContext, codec: Codec[A, Repr]): Future[A] = macro Macros.memoizeImplWithOptionalTTL[A, Repr]
 
   /**
    * Perform the given operation and memoize its result to a cache before returning it.
@@ -96,7 +96,7 @@ package object memoization {
    * @tparam A type of the value to be cached
    * @return the result, either retrieved from the cache or calculated by executing the function `f`
    */
-  def memoizeSync[A](f: => A)(implicit scalaCache: ScalaCache, flags: Flags, codec: Codec[A]): A = macro Macros.memoizeSyncImpl[A]
+  def memoizeSync[A, Repr](f: => A)(implicit scalaCache: ScalaCache[Repr], flags: Flags, codec: Codec[A, Repr]): A = macro Macros.memoizeSyncImpl[A, Repr]
 
   /**
    * Perform the given operation and memoize its result to a cache before returning it.
@@ -116,7 +116,7 @@ package object memoization {
    * @tparam A type of the value to be cached
    * @return the result, either retrieved from the cache or calculated by executing the function `f`
    */
-  def memoizeSync[A](ttl: Duration)(f: => A)(implicit scalaCache: ScalaCache, flags: Flags, codec: Codec[A]): A = macro Macros.memoizeSyncImplWithTTL[A]
+  def memoizeSync[A, Repr](ttl: Duration)(f: => A)(implicit scalaCache: ScalaCache[Repr], flags: Flags, codec: Codec[A, Repr]): A = macro Macros.memoizeSyncImplWithTTL[A, Repr]
 
   /**
    * Perform the given operation and memoize its result to a cache before returning it.
@@ -136,6 +136,6 @@ package object memoization {
    * @tparam A type of the value to be cached
    * @return the result, either retrieved from the cache or calculated by executing the function `f`
    */
-  def memoizeSync[A](optionalTtl: Option[Duration])(f: => A)(implicit scalaCache: ScalaCache, flags: Flags, codec: Codec[A]): A = macro Macros.memoizeSyncImplWithOptionalTTL[A]
+  def memoizeSync[A, Repr](optionalTtl: Option[Duration])(f: => A)(implicit scalaCache: ScalaCache[Repr], flags: Flags, codec: Codec[A, Repr]): A = macro Macros.memoizeSyncImplWithOptionalTTL[A, Repr]
 }
 

--- a/core/src/main/scala/scalacache/serialization/BaseCodecs.scala
+++ b/core/src/main/scala/scalacache/serialization/BaseCodecs.scala
@@ -7,7 +7,15 @@ package scalacache.serialization
  */
 trait BaseCodecs {
 
-  implicit object IntBinaryCodec extends Codec[Int] {
+  /**
+    * Noop Codec that does nothing when you just want to put stuff into in-memory cache representations
+    */
+  implicit def anyToNoSerialization[A] = new Codec[A, InMemoryRepr] {
+    def serialize(value: A): InMemoryRepr = throw new RuntimeException("Cache using InMemoryRepr trying to serialize data")
+    def deserialize(data: InMemoryRepr): A = throw new RuntimeException("Cache using InMemoryRepr trying to deserialize data")
+  }
+
+  implicit object IntBinaryCodec extends Codec[Int, Array[Byte]] {
     def serialize(value: Int): Array[Byte] =
       Array(
         (value >>> 24).asInstanceOf[Byte],
@@ -23,7 +31,7 @@ trait BaseCodecs {
         data(3).asInstanceOf[Int] & 255
   }
 
-  implicit object DoubleBinaryCodec extends Codec[Double] {
+  implicit object DoubleBinaryCodec extends Codec[Double, Array[Byte]] {
     import java.lang.{ Double => JvmDouble }
     def serialize(value: Double): Array[Byte] = {
       val l = JvmDouble.doubleToLongBits(value)
@@ -36,7 +44,7 @@ trait BaseCodecs {
     }
   }
 
-  implicit object FloatBinaryCodec extends Codec[Float] {
+  implicit object FloatBinaryCodec extends Codec[Float, Array[Byte]] {
     import java.lang.{ Float => JvmFloat }
     def serialize(value: Float): Array[Byte] = {
       val i = JvmFloat.floatToIntBits(value)
@@ -49,7 +57,7 @@ trait BaseCodecs {
     }
   }
 
-  implicit object LongBinaryCodec extends Codec[Long] {
+  implicit object LongBinaryCodec extends Codec[Long, Array[Byte]] {
     def serialize(value: Long): Array[Byte] =
       Array(
         (value >>> 56).asInstanceOf[Byte],
@@ -73,7 +81,7 @@ trait BaseCodecs {
         data(7).asInstanceOf[Long] & 255
   }
 
-  implicit object BooleanBinaryCodec extends Codec[Boolean] {
+  implicit object BooleanBinaryCodec extends Codec[Boolean, Array[Byte]] {
     def serialize(value: Boolean): Array[Byte] =
       Array((if (value) 1 else 0).asInstanceOf[Byte])
 
@@ -81,7 +89,7 @@ trait BaseCodecs {
       data.isDefinedAt(0) && data(0) == 1
   }
 
-  implicit object CharBinaryCodec extends Codec[Char] {
+  implicit object CharBinaryCodec extends Codec[Char, Array[Byte]] {
     def serialize(value: Char): Array[Byte] = Array(
       (value >>> 8).asInstanceOf[Byte],
       value.asInstanceOf[Byte]
@@ -93,7 +101,7 @@ trait BaseCodecs {
         .asInstanceOf[Char]
   }
 
-  implicit object ShortBinaryCodec extends Codec[Short] {
+  implicit object ShortBinaryCodec extends Codec[Short, Array[Byte]] {
     def serialize(value: Short): Array[Byte] = Array(
       (value >>> 8).asInstanceOf[Byte],
       value.asInstanceOf[Byte]
@@ -105,12 +113,12 @@ trait BaseCodecs {
         .asInstanceOf[Short]
   }
 
-  implicit object StringBinaryCodec extends Codec[String] {
+  implicit object StringBinaryCodec extends Codec[String, Array[Byte]] {
     def serialize(value: String): Array[Byte] = value.getBytes("UTF-8")
     def deserialize(data: Array[Byte]): String = new String(data, "UTF-8")
   }
 
-  implicit object ArrayByteBinaryCodec extends Codec[Array[Byte]] {
+  implicit object ArrayByteBinaryCodec extends Codec[Array[Byte], Array[Byte]] {
     def serialize(value: Array[Byte]): Array[Byte] = value
     def deserialize(data: Array[Byte]): Array[Byte] = data
   }

--- a/core/src/main/scala/scalacache/serialization/Codec.scala
+++ b/core/src/main/scala/scalacache/serialization/Codec.scala
@@ -7,10 +7,10 @@ import scala.language.implicitConversions
  * Represents a type class that needs to be implemented
  * for serialization/deserialization to work.
  */
-@implicitNotFound("Could not find any Codecs for type ${T}. Please provide one or import scalacache._")
-trait Codec[T] {
-  def serialize(value: T): Array[Byte]
-  def deserialize(data: Array[Byte]): T
+@implicitNotFound("Could not find any Codecs for type ${From} and ${Repr}. Please provide one or import scalacache._")
+trait Codec[From, Repr] {
+  def serialize(value: From): Repr
+  def deserialize(data: Repr): From
 }
 
 /**

--- a/core/src/main/scala/scalacache/serialization/InMemoryRepr.scala
+++ b/core/src/main/scala/scalacache/serialization/InMemoryRepr.scala
@@ -1,0 +1,3 @@
+package scalacache.serialization
+
+sealed trait InMemoryRepr

--- a/core/src/main/scala/scalacache/serialization/JavaSerializationCodec.scala
+++ b/core/src/main/scala/scalacache/serialization/JavaSerializationCodec.scala
@@ -12,7 +12,7 @@ import scala.util.control.NonFatal
   */
 trait JavaSerializationCodec {
 
-  private[this] class GenericCodec[S <: Serializable](classTag: ClassTag[S]) extends Codec[S] {
+  private[this] class GenericCodec[S <: Serializable](classTag: ClassTag[S]) extends Codec[S, Array[Byte]] {
 
     def using[T <: Closeable, R](obj: T)(f: T => R): R =
       try
@@ -43,7 +43,7 @@ trait JavaSerializationCodec {
   /**
     * Uses plain Java serialization to deserialize objects
     */
-  implicit def AnyRefBinaryCodec[S <: Serializable](implicit ev: ClassTag[S]): Codec[S] =
+  implicit def AnyRefBinaryCodec[S <: Serializable](implicit ev: ClassTag[S]): Codec[S, Array[Byte]] =
     new GenericCodec[S](ev)
 
 }

--- a/core/src/test/scala/common/LegacyCodecCheckSupport.scala
+++ b/core/src/test/scala/common/LegacyCodecCheckSupport.scala
@@ -12,7 +12,7 @@ object Snack {
 
 case class Snack(name: String)
 
-class DummySnackCodec extends Codec[Snack] {
+class DummySnackCodec extends Codec[Snack, Array[Byte]] {
   var serialiserUsed = false
   var deserialiserUsed = false
   def serialize(value: Snack): Array[Byte] = {
@@ -34,7 +34,7 @@ trait LegacyCodecCheckSupport { this: FlatSpec with Matchers with ScalaFutures w
    * @param buildCache function that takes a boolean indicating whether not the cache returned should make use of
    *                   in-scope Codecs
    */
-  def legacySupportCheck(buildCache: Boolean => Cache): Unit = {
+  def legacySupportCheck(buildCache: Boolean => Cache[Array[Byte]]): Unit = {
 
     behavior of "useLegacySerialization"
 

--- a/core/src/test/scala/scalacache/PackageObjectSpec.scala
+++ b/core/src/test/scala/scalacache/PackageObjectSpec.scala
@@ -7,6 +7,7 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import scalacache.serialization.InMemoryRepr
 
 class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with ScalaFutures with Eventually {
 
@@ -21,25 +22,25 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
   behavior of "#get"
 
   it should "call get on the cache found in the ScalaCache" in {
-    scalacache.get[String]("foo")
+    scalacache.get[String, InMemoryRepr]("foo")
     cache.getCalledWithArgs(0) should be("foo")
   }
 
   it should "use the CacheKeyBuilder to build the cache key" in {
-    scalacache.get[String]("foo", 123)
+    scalacache.get[String, InMemoryRepr]("foo", 123)
     cache.getCalledWithArgs(0) should be("foo:123")
   }
 
   it should "not call get on the cache found in the ScalaCache if cache reads are disabled" in {
     implicit val flags = Flags(readsEnabled = false)
-    scalacache.get[String]("foo")
+    scalacache.get[String, InMemoryRepr]("foo")
     cache.getCalledWithArgs should be('empty)
   }
 
   it should "conditionally call get on the cache found in the ScalaCache depending on the readsEnabled flag" in {
     def possiblyGetFromCache(key: String): Unit = {
       implicit def flags = Flags(readsEnabled = (key == "foo"))
-      scalacache.get[String](key)
+      scalacache.get[String, InMemoryRepr](key)
     }
     possiblyGetFromCache("foo")
     possiblyGetFromCache("bar")
@@ -80,7 +81,7 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
   behavior of "typed.remove"
 
   it should "concatenate key parts correctly" in {
-    scalacache.typed[String].remove("oh", "wow")
+    scalacache.typed[String, InMemoryRepr].remove("oh", "wow")
     cache.removeCalledWithArgs(0) should be("oh:wow")
   }
 

--- a/core/src/test/scala/scalacache/memoization/CacheKeyExcludingConstructorParamsSpec.scala
+++ b/core/src/test/scala/scalacache/memoization/CacheKeyExcludingConstructorParamsSpec.scala
@@ -1,14 +1,16 @@
 package scalacache.memoization
 
 import org.scalatest._
+
 import scalacache._
 import scalacache.memoization.MethodCallToStringConverter.excludeClassConstructorParams
+import scalacache.serialization.InMemoryRepr
 
 class CacheKeyExcludingConstructorParamsSpec extends FlatSpec with CacheKeySpecCommon {
 
   behavior of "cache key generation for method memoization (not including constructor params in cache key)"
 
-  implicit val scalaCache = ScalaCache(cache, memoization = MemoizationConfig(toStringConverter = excludeClassConstructorParams))
+  implicit val scalaCache: ScalaCache[InMemoryRepr] = ScalaCache(cache, memoization = MemoizationConfig(toStringConverter = excludeClassConstructorParams))
 
   it should "not include the enclosing class's constructor params in the cache key" in {
     val instance1 = new ClassWithConstructorParams(50)

--- a/core/src/test/scala/scalacache/memoization/CacheKeySpecCommon.scala
+++ b/core/src/test/scala/scalacache/memoization/CacheKeySpecCommon.scala
@@ -3,12 +3,13 @@ package scalacache.memoization
 import org.scalatest._
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 
-import scalacache.{ ScalaCache, MockCache }
+import scalacache.serialization.InMemoryRepr
+import scalacache.{ MockCache, ScalaCache }
 
 trait CacheKeySpecCommon extends Suite with Matchers with ScalaFutures with BeforeAndAfter with Eventually {
 
   val cache = new MockCache
-  implicit def scalaCache: ScalaCache
+  implicit def scalaCache: ScalaCache[InMemoryRepr]
 
   before {
     cache.mmap.clear()
@@ -49,7 +50,7 @@ trait CacheKeySpecCommon extends Suite with Matchers with ScalaFutures with Befo
 
 }
 
-class AClass(implicit val scalaCache: ScalaCache) {
+class AClass(implicit val scalaCache: ScalaCache[InMemoryRepr]) {
   def insideClass(a: Int): Int = memoizeSync {
     123
   }
@@ -69,7 +70,7 @@ class AClass(implicit val scalaCache: ScalaCache) {
 }
 
 trait ATrait {
-  implicit val scalaCache: ScalaCache
+  implicit val scalaCache: ScalaCache[InMemoryRepr]
 
   def insideTrait(a: Int): Int = memoizeSync {
     123
@@ -77,21 +78,21 @@ trait ATrait {
 }
 
 object AnObject {
-  implicit var scalaCache: ScalaCache = null
+  implicit var scalaCache: ScalaCache[InMemoryRepr] = null
   def insideObject(a: Int): Int = memoizeSync {
     123
   }
 }
 
 class ClassWithConstructorParams(b: Int) {
-  implicit var scalaCache: ScalaCache = null
+  implicit var scalaCache: ScalaCache[InMemoryRepr] = null
   def foo(a: Int): Int = memoizeSync {
     a + b
   }
 }
 
 class ClassWithExcludedConstructorParam(b: Int, @cacheKeyExclude c: Int) {
-  implicit var scalaCache: ScalaCache = null
+  implicit var scalaCache: ScalaCache[InMemoryRepr] = null
   def foo(a: Int): Int = memoizeSync {
     a + b + c
   }

--- a/core/src/test/scala/scalacache/memoization/MemoizeSpec.scala
+++ b/core/src/test/scala/scalacache/memoization/MemoizeSpec.scala
@@ -1,6 +1,6 @@
 package scalacache.memoization
 
-import org.scalatest.concurrent.{ ScalaFutures, Eventually }
+import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.{ FlatSpec, Matchers }
 
 import scala.collection.mutable.ArrayBuffer
@@ -9,6 +9,7 @@ import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.postfixOps
 import scalacache._
+import scalacache.serialization.InMemoryRepr
 
 class MemoizeSpec extends FlatSpec with Matchers with ScalaFutures with Eventually {
 
@@ -252,7 +253,7 @@ class MemoizeSpec extends FlatSpec with Matchers with ScalaFutures with Eventual
     }
   }
 
-  class MyMockClass(dbCall: Int => String)(implicit val scalaCache: ScalaCache, implicit val flags: Flags) {
+  class MyMockClass(dbCall: Int => String)(implicit val scalaCache: ScalaCache[InMemoryRepr], implicit val flags: Flags) {
 
     def myLongRunningMethod(a: Int, b: String): String = memoizeSync {
       dbCall(a)
@@ -264,7 +265,7 @@ class MemoizeSpec extends FlatSpec with Matchers with ScalaFutures with Eventual
 
   }
 
-  class MyMockClassWithFutures(dbCall: Int => String)(implicit val scalaCache: ScalaCache, implicit val flags: Flags) {
+  class MyMockClassWithFutures(dbCall: Int => String)(implicit val scalaCache: ScalaCache[InMemoryRepr], implicit val flags: Flags) {
 
     def myLongRunningMethod(a: Int, b: String): Future[String] = memoize {
       Future { dbCall(a) }

--- a/core/src/test/scala/scalacache/memoization/pkg/package.scala
+++ b/core/src/test/scala/scalacache/memoization/pkg/package.scala
@@ -1,9 +1,10 @@
 package scalacache.memoization
 
 import scalacache._
+import scalacache.serialization.InMemoryRepr
 
 package object pkg {
-  implicit var scalaCache: ScalaCache = null
+  implicit var scalaCache: ScalaCache[InMemoryRepr] = null
 
   def insidePackageObject(a: Int): Int = memoizeSync {
     123

--- a/core/src/test/scala/scalacache/serialization/BasicCodecsSpec.scala
+++ b/core/src/test/scala/scalacache/serialization/BasicCodecsSpec.scala
@@ -9,8 +9,7 @@ import org.scalatest.prop.GeneratorDrivenPropertyChecks
  */
 class BasicCodecsSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
 
-  private def serdesCheck[A: Arbitrary: Codec]: Unit = {
-    val codec = implicitly[Codec[A]]
+  private def serdesCheck[A: Arbitrary](implicit codec: Codec[A, Array[Byte]]): Unit = {
     forAll { n: A =>
       val serialised = codec.serialize(n)
       val deserialised = codec.deserialize(serialised)

--- a/core/src/test/scala/scalacache/serialization/JavaSerializationCodecSpec.scala
+++ b/core/src/test/scala/scalacache/serialization/JavaSerializationCodecSpec.scala
@@ -6,7 +6,7 @@ class JavaSerializationCodecSpec extends FlatSpec with Matchers {
 
   it should "serialize and deserialize case classes" in {
     val hello = Phone(1, "Apple")
-    val phoneCodec = implicitly[Codec[Phone]]
+    val phoneCodec = implicitly[Codec[Phone, Array[Byte]]]
     val serialised = phoneCodec.serialize(hello)
     phoneCodec.deserialize(serialised) shouldBe hello
   }

--- a/guava/src/main/scala/scalacache/guava/GuavaCache.scala
+++ b/guava/src/main/scala/scalacache/guava/GuavaCache.scala
@@ -1,11 +1,13 @@
 package scalacache.guava
 
-import scalacache.serialization.Codec
-import scalacache.{ LoggingSupport, Cache, Entry }
+import scalacache.serialization.{ Codec, InMemoryRepr }
+import scalacache.{ Cache, Entry, LoggingSupport }
 import com.google.common.cache.{ Cache => GCache, CacheBuilder => GCacheBuilder }
+
 import scala.concurrent.duration.Duration
 import org.joda.time.DateTime
 import com.typesafe.scalalogging.StrictLogging
+
 import scala.concurrent.Future
 
 /*
@@ -17,7 +19,7 @@ import scala.concurrent.Future
  * because Any does not extend java.lang.Object.
  */
 class GuavaCache(underlying: GCache[String, Object])
-    extends Cache
+    extends Cache[InMemoryRepr]
     with LoggingSupport
     with StrictLogging {
 
@@ -28,7 +30,7 @@ class GuavaCache(underlying: GCache[String, Object])
    * @tparam V the type of the corresponding value
    * @return the value, if there is one
    */
-  override def get[V](key: String)(implicit codec: Codec[V]) = {
+  override def get[V](key: String)(implicit codec: Codec[V, InMemoryRepr]) = {
     val entry = Option(underlying.getIfPresent(key).asInstanceOf[Entry[V]])
     /*
      Note: we could delete the entry from the cache if it has expired,
@@ -51,7 +53,7 @@ class GuavaCache(underlying: GCache[String, Object])
    * @param ttl Time To Live
    * @tparam V the type of the corresponding value
    */
-  override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V]) = {
+  override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, InMemoryRepr]) = {
     val entry = Entry(value, ttl.map(toExpiryTime))
     underlying.put(key, entry.asInstanceOf[Object])
     logCachePut(key, ttl)

--- a/memcached/src/test/scala/scalacache/memcached/MemcachedCacheSpec.scala
+++ b/memcached/src/test/scala/scalacache/memcached/MemcachedCacheSpec.scala
@@ -28,7 +28,7 @@ class MemcachedCacheSpec
     } catch { case _: Exception => false }
   }
 
-  def serialise[A](v: A)(implicit codec: Codec[A]): Array[Byte] = codec.serialize(v)
+  def serialise[A](v: A)(implicit codec: Codec[A, Array[Byte]]): Array[Byte] = codec.serialize(v)
 
   if (!memcachedIsRunning) {
     alert("Skipping tests because Memcached does not appear to be running on localhost.")

--- a/redis/src/main/scala/scalacache/redis/RedisCacheBase.scala
+++ b/redis/src/main/scala/scalacache/redis/RedisCacheBase.scala
@@ -15,7 +15,7 @@ import com.typesafe.scalalogging.StrictLogging
  * This is everything apart from `removeAll`, which needs to be implemented differently for sharded Redis.
  */
 trait RedisCacheBase
-    extends Cache
+    extends Cache[Array[Byte]]
     with RedisSerialization
     with LoggingSupport
     with StrictLogging {
@@ -52,7 +52,7 @@ trait RedisCacheBase
    * @tparam V the type of the corresponding value
    * @return the value, if there is one
    */
-  final override def get[V](key: String)(implicit codec: Codec[V]) = Future {
+  final override def get[V](key: String)(implicit codec: Codec[V, Array[Byte]]) = Future {
     blocking {
       withJedisCommands { jedis =>
         val resultBytes = Option(jedis.get(key.utf8bytes))
@@ -71,7 +71,7 @@ trait RedisCacheBase
    * @param ttl Time To Live
    * @tparam V the type of the corresponding value
    */
-  final override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V]) = Future {
+  final override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, Array[Byte]]) = Future {
     blocking {
       withJedisCommands { jedis =>
         val keyBytes = key.utf8bytes

--- a/redis/src/main/scala/scalacache/redis/RedisSerialization.scala
+++ b/redis/src/main/scala/scalacache/redis/RedisSerialization.scala
@@ -21,14 +21,14 @@ trait RedisSerialization {
 
   protected def customClassloader: Option[ClassLoader] = None
 
-  def serialize[A](value: A)(implicit codec: Codec[A]): Array[Byte] = {
+  def serialize[A](value: A)(implicit codec: Codec[A, Array[Byte]]): Array[Byte] = {
     if (useLegacySerialization)
       Legacy.serialize(value)
     else
       codec.serialize(value)
   }
 
-  def deserialize[A](bytes: Array[Byte])(implicit codec: Codec[A]): A = {
+  def deserialize[A](bytes: Array[Byte])(implicit codec: Codec[A, Array[Byte]]): A = {
     if (useLegacySerialization)
       Legacy.deserialize[A](bytes)
     else

--- a/redis/src/test/scala/scalacache/redis/PlayIntegrationSpec.scala
+++ b/redis/src/test/scala/scalacache/redis/PlayIntegrationSpec.scala
@@ -31,7 +31,7 @@ case class Item(id: Int, name: String)
 
 object Global extends GlobalSettings {
   @volatile implicit var jedisPool: JedisPool = _
-  @volatile implicit var scalaCache: ScalaCache = _
+  @volatile implicit var scalaCache: ScalaCache[Array[Byte]] = _
 
   override def onStart(app: Application): Unit = {
     jedisPool = new JedisPool("localhost", 6379)

--- a/redis/src/test/scala/scalacache/redis/RedisCacheSpec.scala
+++ b/redis/src/test/scala/scalacache/redis/RedisCacheSpec.scala
@@ -14,7 +14,7 @@ class RedisCacheSpec
 
   val withJedis = assumingRedisIsRunning _
 
-  def constructCache(pool: JPool, useLegacySerialization: Boolean): Cache = new RedisCache(jedisPool = pool, useLegacySerialization = useLegacySerialization)
+  def constructCache(pool: JPool, useLegacySerialization: Boolean): Cache[Array[Byte]] = new RedisCache(jedisPool = pool, useLegacySerialization = useLegacySerialization)
 
   def flushRedis(client: JClient): Unit = client.flushDB()
 

--- a/redis/src/test/scala/scalacache/redis/RedisCacheSpecBase.scala
+++ b/redis/src/test/scala/scalacache/redis/RedisCacheSpecBase.scala
@@ -27,7 +27,7 @@ trait RedisCacheSpecBase
   type JClient <: JedisCommands with BinaryJedisCommands
 
   def withJedis: ((JPool, JClient) => Unit) => Unit
-  def constructCache(pool: JPool, useLegacySerialisation: Boolean): Cache
+  def constructCache(pool: JPool, useLegacySerialisation: Boolean): Cache[Array[Byte]]
   def flushRedis(client: JClient): Unit
 
   def runTestsIfPossible() = {
@@ -97,7 +97,7 @@ trait RedisCacheSpecBase
 
       behavior of "caching with serialization"
 
-      def roundTrip[V](key: String, value: V)(implicit codec: Codec[V]): Future[Option[V]] = {
+      def roundTrip[V](key: String, value: V)(implicit codec: Codec[V, Array[Byte]]): Future[Option[V]] = {
         cache.put(key, value, None).flatMap(_ => cache.get[V](key))
       }
 

--- a/redis/src/test/scala/scalacache/redis/SentinelRedisCacheSpec.scala
+++ b/redis/src/test/scala/scalacache/redis/SentinelRedisCacheSpec.scala
@@ -14,7 +14,7 @@ class SentinelRedisCacheSpec extends RedisCacheSpecBase {
 
   val withJedis = assumingRedisSentinelIsRunning _
 
-  def constructCache(pool: JPool, useLegacySerialization: Boolean): Cache = new SentinelRedisCache(jedisPool = pool, useLegacySerialization = useLegacySerialization)
+  def constructCache(pool: JPool, useLegacySerialization: Boolean): Cache[Array[Byte]] = new SentinelRedisCache(jedisPool = pool, useLegacySerialization = useLegacySerialization)
 
   def flushRedis(client: JClient): Unit = client.flushDB()
 

--- a/redis/src/test/scala/scalacache/redis/ShardedRedisCacheSpec.scala
+++ b/redis/src/test/scala/scalacache/redis/ShardedRedisCacheSpec.scala
@@ -13,7 +13,7 @@ class ShardedRedisCacheSpec extends RedisCacheSpecBase {
 
   val withJedis = assumingMultipleRedisAreRunning _
 
-  def constructCache(pool: JPool, useLegacySerialization: Boolean): Cache = new ShardedRedisCache(jedisPool = pool, useLegacySerialization = useLegacySerialization)
+  def constructCache(pool: JPool, useLegacySerialization: Boolean): Cache[Array[Byte]] = new ShardedRedisCache(jedisPool = pool, useLegacySerialization = useLegacySerialization)
 
   def flushRedis(client: JClient): Unit = client.getAllShards.asScala.foreach(_.flushDB())
 


### PR DESCRIPTION
A quick implementation of [this idea](https://github.com/cb372/scalacache/pull/91#issuecomment-207808528)

- Extend Codec to have a Repr parameter that represents the end result of performing serialisation with the codec
- Make Cache implementations specify the format in which they store data (corresponds to the kind of Repr
  they need), for example In-memory caches like Guava will specify InMemoryRepr
- Add a no-op Codec[Any, InMemoryRepr] codec