### PR TITLE
Optimisations for get and memoize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea_modules
 *.iml
 *.ipr
+*.jfr
 target
 coveralls-token.txt
 /*.html

--- a/benchmarks/src/test/scala/scalacache/benchmark/ProfilingMemoize.scala
+++ b/benchmarks/src/test/scala/scalacache/benchmark/ProfilingMemoize.scala
@@ -25,9 +25,6 @@ object ProfilingMemoize extends App {
     Future.successful(value)
   }
 
-  // populate the cache
-  put(key)(value)
-
   var result: String = _
   var i = 0L
 

--- a/benchmarks/src/test/scala/scalacache/benchmark/ProfilingMemoize.scala
+++ b/benchmarks/src/test/scala/scalacache/benchmark/ProfilingMemoize.scala
@@ -1,0 +1,40 @@
+package scalacache.benchmark
+
+import com.github.benmanes.caffeine.cache.Caffeine
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scalacache._
+import scalacache.caffeine._
+import scalacache.memoization._
+
+/**
+  * Just runs forever, endlessly calling memoize, so Java Flight Recorder can output sampling data.
+  */
+object ProfilingMemoize extends App {
+
+  val underlyingCache = Caffeine.newBuilder().build[String, Object]()
+  implicit val scalaCache = ScalaCache(CaffeineCache(underlyingCache))
+  val typedCache = typed[String, NoSerialization]
+
+  val key = "key"
+  val value: String = "value"
+
+  def itemCachedMemoize(key: String): Future[String] = memoize {
+    Future.successful(value)
+  }
+
+  // populate the cache
+  put(key)(value)
+
+  var result: String = _
+  var i = 0L
+
+  while(i < Long.MaxValue) {
+    result = Await.result(itemCachedMemoize(key), Duration.Inf)
+    i += 1
+  }
+  println(result)
+
+}

--- a/core/src/main/scala/scalacache/CacheKeyBuilder.scala
+++ b/core/src/main/scala/scalacache/CacheKeyBuilder.scala
@@ -7,6 +7,11 @@ trait CacheKeyBuilder {
    */
   def toCacheKey(parts: Seq[Any])(implicit cacheConfig: CacheConfig): String
 
+  /**
+   * Build a cache key by prepending the configured prefix, if there is one
+   */
+  def stringToCacheKey(key: String)(implicit cacheConfig: CacheConfig): String
+
 }
 
 object DefaultCacheKeyBuilder extends CacheKeyBuilder {
@@ -16,8 +21,47 @@ object DefaultCacheKeyBuilder extends CacheKeyBuilder {
    * Prepends the prefix if there is one.
    */
   override def toCacheKey(parts: Seq[Any])(implicit cacheConfig: CacheConfig): String = {
-    val prefix = cacheConfig.keyPrefix.map(p => s"$p${cacheConfig.keySeparator}") getOrElse ""
-    s"$prefix${parts.mkString(cacheConfig.keySeparator)}"
+    // Implementation note: the type of `parts` will be `WrappedArray` when called from the package object,
+    // so random access is O(1).
+    val sb = new StringBuilder(128)
+    val separator = cacheConfig.keySeparator
+
+    // Add the key prefix if there is one
+    cacheConfig.keyPrefix match {
+      case Some(prefix) =>
+        sb.append(prefix)
+        sb.append(separator)
+      case None => // do nothing
+    }
+
+    var i = 0
+
+    // Add all key parts except the last one, with the separator after each one
+    while (i < parts.size - 1) {
+      sb.append(parts(i))
+      sb.append(separator)
+      i += 1
+    }
+    // Add the final key part
+    if (i < parts.size) {
+      sb.append(parts(i))
+    }
+
+    sb.toString
+  }
+
+  override def stringToCacheKey(key: String)(implicit cacheConfig: CacheConfig): String = {
+    cacheConfig.keyPrefix match {
+      case Some(prefix) =>
+        val separator = cacheConfig.keySeparator
+        val sb = new StringBuilder(prefix.length + separator.length + key.length)
+        sb.append(prefix)
+        sb.append(separator)
+        sb.append(key)
+        sb.toString
+      case None =>
+        key // just return the key as is
+    }
   }
 
 }

--- a/core/src/main/scala/scalacache/package.scala
+++ b/core/src/main/scala/scalacache/package.scala
@@ -12,7 +12,7 @@ package object scalacache extends JavaSerializationCodec {
   // this alias is just for convenience, so you don't need to import serialization._
   type NoSerialization = scalacache.serialization.InMemoryRepr
 
-  class TypedApi[From, Repr](implicit val scalaCache: ScalaCache[Repr], codec: Codec[From, Repr]) {
+  class TypedApi[From, Repr](implicit val scalaCache: ScalaCache[Repr], codec: Codec[From, Repr]) { self =>
 
     def get(keyParts: Any*)(implicit flags: Flags): Future[Option[From]] = getWithKey(toKey(keyParts))
 
@@ -37,8 +37,17 @@ package object scalacache extends JavaSerializationCodec {
       _caching(keyParts: _*)(optionalTtl)(f)
     }
 
+    private[scalacache] def cachingForMemoize(baseKey: String)(ttl: Option[Duration])(f: => Future[From])(implicit flags: Flags, execContext: ExecutionContext): Future[From] = {
+      val key = stringToKey(baseKey)
+      _caching(key)(ttl)(f)
+    }
+
     private def _caching(keyParts: Any*)(ttl: Option[Duration])(f: => Future[From])(implicit flags: Flags, execContext: ExecutionContext): Future[From] = {
       val key = toKey(keyParts)
+      _caching(key)(ttl)(f)
+    }
+
+    private def _caching(key: String)(ttl: Option[Duration])(f: => Future[From])(implicit flags: Flags, execContext: ExecutionContext): Future[From] = {
 
       def asynchronouslyCacheResult(result: Future[From]): Unit = result onSuccess {
         case computedValue =>
@@ -101,6 +110,11 @@ package object scalacache extends JavaSerializationCodec {
 
       def cachingWithTTL(keyParts: Any*)(ttl: Duration)(f: => From)(implicit flags: Flags): From = {
         _cachingSync(keyParts: _*)(Some(ttl))(f)
+      }
+
+      private[scalacache] def cachingForMemoize(baseKey: String)(ttl: Option[Duration])(f: => From)(implicit flags: Flags): From = {
+        val future = self.cachingForMemoize(baseKey)(ttl)(Future.successful(f))(flags, ExecutionContext.global)
+        Await.result(future, Duration.Inf)
       }
 
       /*
@@ -242,8 +256,15 @@ package object scalacache extends JavaSerializationCodec {
   def cachingWithOptionalTTL[V, Repr](keyParts: Any*)(optionalTtl: Option[Duration])(f: => Future[V])(implicit scalaCache: ScalaCache[Repr], flags: Flags, execContext: ExecutionContext = ExecutionContext.global, codec: Codec[V, Repr]): Future[V] =
     typed[V, Repr].cachingWithOptionalTTL(keyParts: _*)(optionalTtl)(f)
 
+  // Note: this is public because the macro inserts a call to this method into client code
+  def cachingForMemoize[V, Repr](key: String)(optionalTtl: Option[Duration])(f: => Future[V])(implicit scalaCache: ScalaCache[Repr], flags: Flags, execContext: ExecutionContext = ExecutionContext.global, codec: Codec[V, Repr]): Future[V] =
+    typed[V, Repr].cachingForMemoize(key)(optionalTtl)(f)
+
   private def toKey(parts: Seq[Any])(implicit scalaCache: ScalaCache[_]): String =
     scalaCache.keyBuilder.toCacheKey(parts)(scalaCache.cacheConfig)
+
+  private def stringToKey(string: String)(implicit scalaCache: ScalaCache[_]): String =
+    scalaCache.keyBuilder.stringToCacheKey(string)(scalaCache.cacheConfig)
 
   /**
    * Synchronous API, for the case when you don't want to deal with Futures.
@@ -314,6 +335,10 @@ package object scalacache extends JavaSerializationCodec {
         case None => typed[V, Repr].sync.caching(keyParts: _*)(f)
       }
     }
+
+    // Note: this is public because the macro inserts a call to this method into client code
+    def cachingForMemoize[V, Repr](key: String)(optionalTtl: Option[Duration])(f: => V)(implicit scalaCache: ScalaCache[Repr], flags: Flags, codec: Codec[V, Repr]): V =
+      typed[V, Repr].sync.cachingForMemoize(key)(optionalTtl)(f)
 
   }
 

--- a/core/src/test/scala/scalacache/DefaultCacheKeyBuilderSpec.scala
+++ b/core/src/test/scala/scalacache/DefaultCacheKeyBuilderSpec.scala
@@ -18,4 +18,8 @@ class DefaultCacheKeyBuilderSpec extends FlatSpec with Matchers {
     DefaultCacheKeyBuilder.toCacheKey(Seq("abc", 123))(CacheConfig(keyPrefix = Some("foo"))) should be("foo:abc:123")
   }
 
+  it should "Prepend the key prefix to a single string if one is configured" in {
+    DefaultCacheKeyBuilder.stringToCacheKey("abc")(CacheConfig(keyPrefix = Some("foo"))) should be("foo:abc")
+  }
+
 }

--- a/core/src/test/scala/scalacache/memoization/MethodCallToStringConverterSpec.scala
+++ b/core/src/test/scala/scalacache/memoization/MethodCallToStringConverterSpec.scala
@@ -10,38 +10,38 @@ class MethodCallToStringConverterSpec extends FlatSpec with Matchers {
   behavior of "excludeClassConstructorParams"
 
   it should "build a key for a no-arg method with no class" in {
-    excludeClassConstructorParams.toString("", Nil, "myMethod", Nil) should be("myMethod")
+    excludeClassConstructorParams.toString("", Vector.empty, "myMethod", Vector.empty) should be("myMethod")
   }
 
   it should "build a key for a no-arg method" in {
-    excludeClassConstructorParams.toString("MyClass", Nil, "myMethod", Nil) should be("MyClass.myMethod")
+    excludeClassConstructorParams.toString("MyClass", Vector.empty, "myMethod", Vector.empty) should be("MyClass.myMethod")
   }
 
   it should "build a key for a one-arg method" in {
-    excludeClassConstructorParams.toString("MyClass", Nil, "myMethod", List(List("foo"))) should be("MyClass.myMethod(foo)")
+    excludeClassConstructorParams.toString("MyClass", Vector.empty, "myMethod", Vector(Vector("foo"))) should be("MyClass.myMethod(foo)")
   }
 
   it should "build a key for a two-arg method" in {
-    excludeClassConstructorParams.toString("MyClass", Nil, "myMethod", List(List("foo", 123))) should be("MyClass.myMethod(foo, 123)")
+    excludeClassConstructorParams.toString("MyClass", Vector.empty, "myMethod", Vector(Vector("foo", 123))) should be("MyClass.myMethod(foo, 123)")
   }
 
   it should "build a key for a method with multiple argument lists" in {
-    excludeClassConstructorParams.toString("MyClass", Nil, "myMethod", List(List("foo", 123), List(3.0))) should be("MyClass.myMethod(foo, 123)(3.0)")
+    excludeClassConstructorParams.toString("MyClass", Vector.empty, "myMethod", Vector(Vector("foo", 123), Vector(3.0))) should be("MyClass.myMethod(foo, 123)(3.0)")
   }
 
   it should "ignore class constructor arguments" in {
-    excludeClassConstructorParams.toString("MyClass", List(List("foo", "bar")), "myMethod", Nil) should be("MyClass.myMethod")
+    excludeClassConstructorParams.toString("MyClass", Vector(Vector("foo", "bar")), "myMethod", Vector.empty) should be("MyClass.myMethod")
   }
 
   behavior of "includeClassConstructorParams"
 
   it should "build a key for a method with multiple argument lists" in {
     includeClassConstructorParams.toString(
-      "MyClass", List(List("foo", "bar"), List("baz")), "myMethod", List(List("foo", 123), List(3.0))) should be("MyClass(foo, bar)(baz).myMethod(foo, 123)(3.0)")
+      "MyClass", Vector(Vector("foo", "bar"), Vector("baz")), "myMethod", Vector(Vector("foo", 123), Vector(3.0))) should be("MyClass(foo, bar)(baz).myMethod(foo, 123)(3.0)")
   }
 
   it should "build a key for a method in an object" in {
-    includeClassConstructorParams.toString("MyObject", Nil, "myMethod", Nil) should be("MyObject.myMethod")
+    includeClassConstructorParams.toString("MyObject", Vector.empty, "myMethod", Vector.empty) should be("MyObject.myMethod")
   }
 
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -92,7 +92,9 @@ object ScalaCacheBuild extends Build {
     .settings(
       scalaVersion := ScalaVersion,
       publishArtifact := false,
-      javaOptions in Jmh ++= Seq("-server", "-Xms2G", "-Xmx2G", "-XX:+UseG1GC", "-XX:-UseBiasedLocking")
+      fork in (Compile, run) := true,
+      javaOptions in Jmh ++= Seq("-server", "-Xms2G", "-Xmx2G", "-XX:+UseG1GC", "-XX:-UseBiasedLocking"),
+      javaOptions in (Test, run) ++= Seq("-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder", "-XX:StartFlightRecording=delay=20s,duration=60s,filename=memoize.jfr", "-server", "-Xms2G", "-Xmx2G", "-XX:+UseG1GC", "-XX:-UseBiasedLocking")
     )
     .dependsOn(caffeine)
 


### PR DESCRIPTION
Optimization of `get`, `caching` and `memoize`

* Hand-optimise `CacheKeyBuilder` (used by both `get` and `memoize`) to use a loop and a StringBuilder
* Hand-optimise `MethodCallToStringConverter` (used by `memoize`) similarly
* Special treatment for `memoize` because we know in this case that the key is a single string, not an `Any*`
* Special handling in `_caching` for already-completed futures (such as those returned by the in-memory cache implementations). If the future is already completed, we can avoid calling `recover` and `flatMap` on it, which means we avoid spawning more futures. This makes a HUGE difference. This one optimisation accounts for the vast majority of the speedup.

## Before

```
[info] Benchmark                                      Mode  Cnt      Score      Error  Units
[info] CaffeineBenchmark.caffeineGet                  avgt   30     20.547 ±    0.596  ns/op
[info] CaffeineBenchmark.scalacacheGetNoMemoize       avgt   30    334.866 ±   32.630  ns/op
[info] CaffeineBenchmark.scalacacheGetTypedNoMemoize  avgt   30    340.825 ±   36.284  ns/op
[info] CaffeineBenchmark.scalacacheGetWithMemoize     avgt   30  39801.345 ± 2974.877  ns/op
```

## After

```
[info] Benchmark                                      Mode  Cnt    Score     Error  Units
[info] CaffeineBenchmark.caffeineGet                  avgt   30   20.110 ±   0.270  ns/op
[info] CaffeineBenchmark.scalacacheGetNoMemoize       avgt   30  198.882 ±  10.764  ns/op
[info] CaffeineBenchmark.scalacacheGetTypedNoMemoize  avgt   30  206.160 ±  12.344  ns/op
[info] CaffeineBenchmark.scalacacheGetWithMemoize     avgt   30  580.810 ± 129.729  ns/op
```

Not bad for an afternoon's work 😄  

/cc @wuservices @ben-manes in case you're interested