### PR TITLE
logCacheHitOrMiss flag has now been placed at the call site

### DIFF
--- a/caffeine/src/main/scala/scalacache/caffeine/CaffeineCache.scala
+++ b/caffeine/src/main/scala/scalacache/caffeine/CaffeineCache.scala
@@ -43,7 +43,8 @@ class CaffeineCache(underlying: CCache[String, Object])
         if (entry.isExpired) None else Some(entry.value)
       } else None
     }
-    logCacheHitOrMiss(key, result)
+    if (logger.isDebugEnabled)
+      logCacheHitOrMiss(key, result)
     Future.successful(result)
   }
 

--- a/core/src/main/scala/scalacache/LoggingSupport.scala
+++ b/core/src/main/scala/scalacache/LoggingSupport.scala
@@ -19,10 +19,8 @@ trait LoggingSupport {
    * @tparam A the type of the cache value
    */
   protected def logCacheHitOrMiss[A](key: String, result: Option[A]): Unit = {
-    if (logger.isDebugEnabled) {
-      val hitOrMiss = result.map(_ => "hit") getOrElse "miss"
-      logger.debug(s"Cache $hitOrMiss for key $key")
-    }
+    val hitOrMiss = result.map(_ => "hit") getOrElse "miss"
+    logger.debug(s"Cache $hitOrMiss for key $key")
   }
 
   /**

--- a/ehcache/src/main/scala/scalacache/ehcache/EhcacheCache.scala
+++ b/ehcache/src/main/scala/scalacache/ehcache/EhcacheCache.scala
@@ -33,8 +33,8 @@ class EhcacheCache(underlying: Ehcache)
       if (elem == null) None
       else Option(elem.getObjectValue.asInstanceOf[V])
     }
-
-    logCacheHitOrMiss(key, result)
+    if (logger.isDebugEnabled)
+      logCacheHitOrMiss(key, result)
     Future.successful(result)
   }
 

--- a/guava/src/main/scala/scalacache/guava/GuavaCache.scala
+++ b/guava/src/main/scala/scalacache/guava/GuavaCache.scala
@@ -44,7 +44,8 @@ class GuavaCache(underlying: GCache[String, Object])
         if (entry.isExpired) None else Some(entry.value)
       } else None
     }
-    logCacheHitOrMiss(key, result)
+    if (logger.isDebugEnabled)
+      logCacheHitOrMiss(key, result)
     Future.successful(result)
   }
 

--- a/memcached/src/main/scala/scalacache/memcached/MemcachedCache.scala
+++ b/memcached/src/main/scala/scalacache/memcached/MemcachedCache.scala
@@ -46,7 +46,8 @@ class MemcachedCache(client: MemcachedClient,
               Some(codec.deserialize(baseResult.asInstanceOf[Array[Byte]]))
           } else None
         }
-        logCacheHitOrMiss(key, result)
+        if (logger.isDebugEnabled)
+          logCacheHitOrMiss(key, result)
         Success(result)
       }
     })

--- a/redis/src/main/scala/scalacache/redis/RedisCacheBase.scala
+++ b/redis/src/main/scala/scalacache/redis/RedisCacheBase.scala
@@ -63,7 +63,8 @@ trait RedisCacheBase
             Some(deserialize[V](bytes))
           } else None
         }
-        logCacheHitOrMiss(key, result)
+        if (logger.isDebugEnabled)
+          logCacheHitOrMiss(key, result)
         result
       }
     }


### PR DESCRIPTION
This just moves the `logger.isDebugEnabled` at the call site, rather than within the `logCacheHitOrMiss` function call.

I think this should improve performance, should probably verify with benchmarks