### PR TITLE
Enables to invalidate cache

### DIFF
--- a/core/src/main/scala/scalacache/Flags.scala
+++ b/core/src/main/scala/scalacache/Flags.scala
@@ -2,12 +2,18 @@ package scalacache
 
 /**
  * Configuration flags for conditionally altering the behaviour of ScalaCache.
+ * <p>
+ * The difference between `invalidateEnabled = true` and `readsEnabled = false` is that
+ * the former guarantees that the new value is available in the cache once the `Future` is complete
+ * whereas the latter doesn't, in other words, writing to the cache can be still in progress.
  *
  * @param readsEnabled if false, cache GETs will be skipped (and will return `None`)
  * @param writesEnabled if false, cache PUTs will be skipped
+ * @param invalidateEnabled if true, invalidate the cache. if true, `readsEnabled` and `writesEnabled` are ignored.
  */
 case class Flags(readsEnabled: Boolean = true,
-                 writesEnabled: Boolean = true)
+                 writesEnabled: Boolean = true,
+                 invalidateEnabled: Boolean = false)
 
 object Flags {
 


### PR DESCRIPTION
Add `Flags.invalidateEnabled` and change the cache behavior when it's set to true.

I'm not sure how to write tests for this. Writing to cache in tests seems to be an in memory operation, and end immediately, so reproducing the asynchronous issue might require a bit more than adding a simple test case.

Related issue: https://github.com/cb372/scalacache/issues/118