### PR TITLE
Make the write semantics of `caching` configurable

### DIFF
--- a/core/shared/src/main/scala/scalacache/CacheConfig.scala
+++ b/core/shared/src/main/scala/scalacache/CacheConfig.scala
@@ -7,8 +7,16 @@ package scalacache
  *                  Useful for namespacing if you are sharing your cache with another application.
  * @param keySeparator
  *                     The value used to separate different parts of a cache key
+ * @param waitForWriteToComplete
+ *                               If true, the `Future` returned by `caching` (or `memoize`) will not complete
+ *                               until the cache write has completed.
+ *                               If false, the `Future` will complete as soon as the value has been computed,
+ *                               and the cache write will happen asynchronously.
+ *                               The latter was the behaviour until ScalaCache 0.9.2,
+ *                               but the former is more useful in many situations.
  *
  */
 case class CacheConfig(
   keyPrefix: Option[String] = None,
-  keySeparator: String = ":")
+  keySeparator: String = ":",
+  waitForWriteToComplete: Boolean = true)


### PR DESCRIPTION
By default, do not complete the `Future` until the cache write has completed. This makes the behaviour deterministic, as you have a guarantee that the value is now present in the cache when the Future completes.

Note that this is a change in behaviour. Until now, ScalaCache would complete the Future as quickly as possible once the value had been computed, and perform the cache write in the background. It is possible to maintain this behaviour by toggling a boolean in the config.