### PR TITLE
Switch from joda-time to Java 8 time

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The following cache implementations are supported, and it's easy to plugin your 
 
 ScalaCache is available for Scala 2.11.x and 2.12.x.
 
+The JVM must be Java 8 or newer.
+
 ## How to use
 
 ### ScalaCache instance
@@ -447,8 +449,6 @@ implicit val scalaCache = ScalaCache(RedisCache(jedis))
 ScalaCache also supports [sharded Redis](https://github.com/xetorthio/jedis/wiki/AdvancedUsage#shardedjedis) and [Redis Sentinel](http://redis.io/topics/sentinel). Just create a `ShardedRedisCache` or `SentinelRedisCache` respectively.
 
 ## Caffeine
-
-Note that Caffeine requires Java 8 or newer.
 
 SBT:
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,19 +16,20 @@ lazy val root = Project(id = "scalacache", base = file("."))
   .settings(publishArtifact := false)
   .aggregate(coreJS, coreJVM, guava, memcached, ehcache, redis, caffeine)
 
-lazy val core = CrossProject(id = "scalacache-core", file("core"), CrossType.Full)
-  .settings(commonSettings: _*)
-  .settings(
-    moduleName := "scalacache-core",
-    libraryDependencies ++= Seq(
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "org.scalacheck" %% "scalacheck" % "1.13.4" % Test
-    ),
-    scala211OnlyDeps(
-      "org.squeryl" %% "squeryl" % "0.9.5-7" % Test,
-      "com.h2database" % "h2" % "1.4.182" % Test
+lazy val core =
+  CrossProject(id = "scalacache-core", file("core"), CrossType.Full)
+    .settings(commonSettings: _*)
+    .settings(
+      moduleName := "scalacache-core",
+      libraryDependencies ++= Seq(
+        "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+        "org.scalacheck" %% "scalacheck" % "1.13.4" % Test
+      ),
+      scala211OnlyDeps(
+        "org.squeryl" %% "squeryl" % "0.9.5-7" % Test,
+        "com.h2database" % "h2" % "1.4.182" % Test
+      )
     )
-  )
 
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js
@@ -43,14 +44,15 @@ lazy val guava = Project(id = "scalacache-guava", base = file("guava"))
   )
   .dependsOn(coreJVM)
 
-lazy val memcached = Project(id = "scalacache-memcached", base = file("memcached"))
-  .settings(implProjectSettings: _*)
-  .settings(
-    libraryDependencies ++= Seq(
-      "net.spy" % "spymemcached" % "2.12.3"
+lazy val memcached =
+  Project(id = "scalacache-memcached", base = file("memcached"))
+    .settings(implProjectSettings: _*)
+    .settings(
+      libraryDependencies ++= Seq(
+        "net.spy" % "spymemcached" % "2.12.3"
+      )
     )
-  )
-  .dependsOn(coreJVM % "test->test;compile->compile")
+    .dependsOn(coreJVM % "test->test;compile->compile")
 
 lazy val ehcache = Project(id = "scalacache-ehcache", base = file("ehcache"))
   .settings(implProjectSettings: _*)
@@ -71,15 +73,16 @@ lazy val redis = Project(id = "scalacache-redis", base = file("redis"))
   )
   .dependsOn(coreJVM % "test->test;compile->compile")
 
-lazy val caffeine = Project(id = "scalacache-caffeine", base = file("caffeine"))
-  .settings(implProjectSettings: _*)
-  .settings(
-    libraryDependencies ++= Seq(
-      "com.github.ben-manes.caffeine" % "caffeine" % "2.5.3",
-      "com.google.code.findbugs" % "jsr305" % "3.0.0" % "provided"
+lazy val caffeine =
+  Project(id = "scalacache-caffeine", base = file("caffeine"))
+    .settings(implProjectSettings: _*)
+    .settings(
+      libraryDependencies ++= Seq(
+        "com.github.ben-manes.caffeine" % "caffeine" % "2.5.3",
+        "com.google.code.findbugs" % "jsr305" % "3.0.0" % "provided"
+      )
     )
-  )
-  .dependsOn(coreJVM)
+    .dependsOn(coreJVM)
 
 lazy val benchmarks = Project(id = "benchmarks", base = file("benchmarks"))
   .enablePlugins(JmhPlugin)
@@ -87,7 +90,11 @@ lazy val benchmarks = Project(id = "benchmarks", base = file("benchmarks"))
     scalaVersion := ScalaVersion,
     publishArtifact := false,
     fork in (Compile, run) := true,
-    javaOptions in Jmh ++= Seq("-server", "-Xms2G", "-Xmx2G", "-XX:+UseG1GC", "-XX:-UseBiasedLocking"),
+    javaOptions in Jmh ++= Seq("-server",
+                               "-Xms2G",
+                               "-Xmx2G",
+                               "-XX:+UseG1GC",
+                               "-XX:-UseBiasedLocking"),
     javaOptions in (Test, run) ++= Seq(
       "-XX:+UnlockCommercialFeatures",
       "-XX:+FlightRecorder",
@@ -101,11 +108,6 @@ lazy val benchmarks = Project(id = "benchmarks", base = file("benchmarks"))
   )
   .dependsOn(caffeine)
 
-lazy val jodaTime = Seq(
-  "joda-time" % "joda-time" % "2.9.9",
-  "org.joda" % "joda-convert" % "1.8.2"
-)
-
 lazy val slf4j = Seq(
   "org.slf4j" % "slf4j-api" % "1.7.25"
 )
@@ -115,10 +117,7 @@ lazy val scalaTest = Seq(
 )
 
 // Dependencies common to all projects
-lazy val commonDeps =
-  slf4j ++
-    scalaTest ++
-    jodaTime
+lazy val commonDeps = slf4j ++ scalaTest
 
 lazy val commonSettings =
   Defaults.coreDefaultSettings ++
@@ -148,7 +147,8 @@ lazy val commonSettings =
         releaseStepCommand("sonatypeReleaseAll"),
         pushChanges
       ),
-      commands += Command.command("update-version-in-readme")(updateVersionInReadme)
+      commands += Command.command("update-version-in-readme")(
+        updateVersionInReadme)
     )
 
 lazy val implProjectSettings = commonSettings
@@ -194,15 +194,21 @@ lazy val updateVersionInReadme = ReleaseStep(action = st => {
 
   println(s"Updating project version to $projectVersion in the README")
   Process(
-    Seq("sed",
-        "-i",
-        "",
-        "-E",
-        "-e",
-        s"""s/"scalacache-(.*)" % ".*"/"scalacache-\\1" % "$projectVersion"/g""",
-        "README.md")).!
+    Seq(
+      "sed",
+      "-i",
+      "",
+      "-E",
+      "-e",
+      s"""s/"scalacache-(.*)" % ".*"/"scalacache-\\1" % "$projectVersion"/g""",
+      "README.md")).!
   println("Committing README.md")
-  Process(Seq("git", "commit", "README.md", "-m", s"Update project version in README to $projectVersion")).!
+  Process(
+    Seq("git",
+        "commit",
+        "README.md",
+        "-m",
+        s"Update project version in README to $projectVersion")).!
 
   st
 })

--- a/caffeine/src/main/scala/scalacache/caffeine/CaffeineCache.scala
+++ b/caffeine/src/main/scala/scalacache/caffeine/CaffeineCache.scala
@@ -1,11 +1,13 @@
 package scalacache.caffeine
 
+import java.time.{Clock, Instant}
+import java.time.temporal.ChronoUnit
+
 import com.github.benmanes.caffeine.cache.{Caffeine, Cache => CCache}
-import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
+
 import scalacache.serialization.{Codec, InMemoryRepr}
 import scalacache.{Cache, Entry, LoggingSupport}
-
 import scala.concurrent.duration.Duration
 import scala.concurrent.Future
 
@@ -17,7 +19,8 @@ import scala.concurrent.Future
  * Note: Would be nice to use Any here, but that doesn't conform to CCache's type bounds,
  * because Any does not extend java.lang.Object.
  */
-class CaffeineCache(underlying: CCache[String, Object])
+class CaffeineCache(underlying: CCache[String, Object])(implicit clock: Clock =
+                                                          Clock.systemUTC())
     extends Cache[InMemoryRepr]
     with LoggingSupport {
 
@@ -79,8 +82,8 @@ class CaffeineCache(underlying: CCache[String, Object])
     // Nothing to do
   }
 
-  private def toExpiryTime(ttl: Duration): DateTime =
-    DateTime.now.plus(ttl.toMillis)
+  private def toExpiryTime(ttl: Duration): Instant =
+    Instant.now(clock).plus(ttl.toMillis, ChronoUnit.MILLIS)
 
 }
 

--- a/core/shared/src/main/scala/scalacache/Entry.scala
+++ b/core/shared/src/main/scala/scalacache/Entry.scala
@@ -1,15 +1,15 @@
 package scalacache
 
-import org.joda.time.DateTime
+import java.time.{Clock, Instant}
 
 /**
  * A cache entry with an optional expiry time
  */
-case class Entry[+A](value: A, expiresAt: Option[DateTime]) {
+case class Entry[+A](value: A, expiresAt: Option[Instant]) {
 
   /**
    * Has the entry expired yet?
    */
-  def isExpired: Boolean = expiresAt.exists(_.isBeforeNow)
+  def isExpired(implicit clock: Clock): Boolean = expiresAt.exists(_.isBefore(Instant.now(clock)))
 
 }

--- a/guava/src/main/scala/scalacache/guava/GuavaCache.scala
+++ b/guava/src/main/scala/scalacache/guava/GuavaCache.scala
@@ -1,6 +1,8 @@
 package scalacache.guava
 
-import org.joda.time.DateTime
+import java.time.temporal.ChronoUnit
+import java.time.{Clock, Instant}
+
 import org.slf4j.LoggerFactory
 
 import scalacache.serialization.{Codec, InMemoryRepr}
@@ -18,7 +20,8 @@ import scala.concurrent.Future
  * Note: Would be nice to use Any here, but that doesn't conform to GCache's type bounds,
  * because Any does not extend java.lang.Object.
  */
-class GuavaCache(underlying: GCache[String, Object])
+class GuavaCache(underlying: GCache[String, Object])(implicit clock: Clock =
+                                                       Clock.systemUTC())
     extends Cache[InMemoryRepr]
     with LoggingSupport {
 
@@ -80,8 +83,8 @@ class GuavaCache(underlying: GCache[String, Object])
     // Nothing to do
   }
 
-  private def toExpiryTime(ttl: Duration): DateTime =
-    DateTime.now.plus(ttl.toMillis)
+  private def toExpiryTime(ttl: Duration): Instant =
+    Instant.now(clock).plus(ttl.toMillis, ChronoUnit.MILLIS)
 
 }
 

--- a/guava/src/test/scala/scalacache/guava/GuavaCacheSpec.scala
+++ b/guava/src/test/scala/scalacache/guava/GuavaCacheSpec.scala
@@ -1,17 +1,15 @@
 package scalacache.guava
 
+import java.time.{Clock, Instant, ZoneOffset}
+
 import scalacache.Entry
-import org.scalatest.{BeforeAndAfter, Matchers, FlatSpec}
+import org.scalatest.{FlatSpec, Matchers}
 import com.google.common.cache.CacheBuilder
-import org.joda.time.{DateTimeUtils, DateTime}
+
 import scala.concurrent.duration._
 import org.scalatest.concurrent.ScalaFutures
 
-class GuavaCacheSpec
-    extends FlatSpec
-    with Matchers
-    with BeforeAndAfter
-    with ScalaFutures {
+class GuavaCacheSpec extends FlatSpec with Matchers with ScalaFutures {
 
   def newGCache = CacheBuilder.newBuilder.build[String, Object]
 
@@ -37,7 +35,7 @@ class GuavaCacheSpec
   it should "return None if the given key exists but the value has expired" in {
     val underlying = newGCache
     val expiredEntry =
-      Entry("hello", expiresAt = Some(DateTime.now.minusSeconds(1)))
+      Entry("hello", expiresAt = Some(Instant.now.minusSeconds(1)))
     underlying.put("key1", expiredEntry)
     whenReady(GuavaCache(underlying).get[String]("non-existent key")) {
       result =>
@@ -56,23 +54,23 @@ class GuavaCacheSpec
   behavior of "put with TTL"
 
   it should "store the given key-value pair in the underlying cache with the given TTL" in {
-    val now = DateTime.now
-    DateTimeUtils.setCurrentMillisFixed(now.getMillis)
+    val now = Instant.now()
+    val clock = Clock.fixed(now, ZoneOffset.UTC)
 
     val underlying = newGCache
-    GuavaCache(underlying).put("key1", "hello", Some(10.seconds))
+    new GuavaCache(underlying)(clock).put("key1", "hello", Some(10.seconds))
     underlying.getIfPresent("key1") should be(
-      Entry("hello", expiresAt = Some(now.plusSeconds(10))))
+      Entry("hello", expiresAt = Some(Instant.from(now.plusSeconds(10)))))
   }
 
   it should "support a TTL greater than Int.MaxValue millis" in {
-    val now = new DateTime("2015-10-01T00:00:00Z")
-    DateTimeUtils.setCurrentMillisFixed(now.getMillis)
+    val now = Instant.parse("2015-10-01T00:00:00Z")
+    val clock = Clock.fixed(now, ZoneOffset.UTC)
 
     val underlying = newGCache
-    GuavaCache(underlying).put("key1", "hello", Some(30.days))
+    new GuavaCache(underlying)(clock).put("key1", "hello", Some(30.days))
     underlying.getIfPresent("key1") should be(
-      Entry("hello", expiresAt = Some(new DateTime("2015-10-31T00:00:00Z"))))
+      Entry("hello", expiresAt = Some(Instant.parse("2015-10-31T00:00:00Z"))))
   }
 
   behavior of "remove"
@@ -85,10 +83,6 @@ class GuavaCacheSpec
 
     GuavaCache(underlying).remove("key1")
     underlying.getIfPresent("key1") should be(null)
-  }
-
-  after {
-    DateTimeUtils.setCurrentMillisSystem()
   }
 
 }

--- a/memcached/src/test/scala/scalacache/memcached/MemcachedTTLConverterSpec.scala
+++ b/memcached/src/test/scala/scalacache/memcached/MemcachedTTLConverterSpec.scala
@@ -1,13 +1,15 @@
 package scalacache.memcached
 
-import org.scalatest.{BeforeAndAfter, Matchers, FlatSpec}
+import java.time.temporal.ChronoUnit
+import java.time.{Clock, Instant, ZoneOffset}
+
+import org.scalatest.{FlatSpec, Matchers}
+
 import scala.concurrent.duration._
-import org.joda.time.{DateTimeZone, DateTime, DateTimeUtils}
 
 class MemcachedTTLConverterSpec
     extends FlatSpec
     with Matchers
-    with BeforeAndAfter
     with MemcachedTTLConverter {
   behavior of "MemcachedTTLConverter"
 
@@ -36,14 +38,10 @@ class MemcachedTTLConverterSpec
   }
 
   it should "convert a duration longer than 30 days to the expiry time expressed as UNIX epoch seconds" in {
-    val now = DateTime.now(DateTimeZone.UTC)
-    DateTimeUtils.setCurrentMillisFixed(now.getMillis)
-    toMemcachedExpiry(Some(31.days)) should be(
-      now.plusDays(31).getMillis / 1000)
-  }
-
-  after {
-    DateTimeUtils.setCurrentMillisSystem()
+    val now = Instant.now()
+    val clock = Clock.fixed(now, ZoneOffset.UTC)
+    toMemcachedExpiry(Some(31.days))(clock) should be(
+      now.plus(31, ChronoUnit.DAYS).toEpochMilli / 1000)
   }
 
 }


### PR DESCRIPTION
Just for the sake of removing a 3rd-party dependency.

I thought this might break Scala.js support, but a bit of investigation shows that it's probably already broken anyway, as core was depending on joda-time and slf4j. Will need some more work to sort out Scala.js support in general.