### PR TITLE
Make the return types more generic

### DIFF
--- a/modules/core/shared/src/main/scala/scalacache/Cache.scala
+++ b/modules/core/shared/src/main/scala/scalacache/Cache.scala
@@ -23,7 +23,7 @@ trait Cache[Repr] {
    * @param ttl Time To Live
    * @tparam V the type of the corresponding value
    */
-  def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, Repr]): Future[Unit]
+  def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, Repr]): Future[Any]
 
   /**
    * Remove the given key and its associated value from the cache, if it exists.
@@ -31,12 +31,12 @@ trait Cache[Repr] {
    *
    * @param key cache key
    */
-  def remove(key: String): Future[Unit]
+  def remove(key: String): Future[Any]
 
   /**
    * Delete the entire contents of the cache. Use wisely!
    */
-  def removeAll(): Future[Unit]
+  def removeAll(): Future[Any]
 
   /**
    * You should call this when you have finished using this Cache.

--- a/modules/core/shared/src/main/scala/scalacache/package.scala
+++ b/modules/core/shared/src/main/scala/scalacache/package.scala
@@ -17,13 +17,13 @@ package object scalacache extends JavaSerializationCodec {
 
     def get(keyParts: Any*)(implicit flags: Flags): Future[Option[From]] = getWithKey(toKey(keyParts))
 
-    def put(keyParts: Any*)(value: From, ttl: Option[Duration] = None)(implicit flags: Flags): Future[Unit] =
+    def put(keyParts: Any*)(value: From, ttl: Option[Duration] = None)(implicit flags: Flags): Future[Any] =
       putWithKey(toKey(keyParts), value, ttl)
 
-    def remove(keyParts: Any*): Future[Unit] =
+    def remove(keyParts: Any*): Future[Any] =
       scalacache.remove(keyParts: _*)
 
-    def removeAll(): Future[Unit] =
+    def removeAll(): Future[Any] =
       scalacache.removeAll()
 
     def caching(keyParts: Any*)(f: => Future[From])(implicit flags: Flags, execContext: ExecutionContext = ExecutionContext.global): Future[From] = {
@@ -122,7 +122,7 @@ package object scalacache extends JavaSerializationCodec {
       }
     }
 
-    private def putWithKey(key: String, value: From, ttl: Option[Duration] = None)(implicit flags: Flags): Future[Unit] = {
+    private def putWithKey(key: String, value: From, ttl: Option[Duration] = None)(implicit flags: Flags): Future[Any] = {
       if (flags.writesEnabled) {
         val finiteTtl = ttl.filter(_.isFinite()) // discard Duration.Inf, Duration.Undefined
         scalaCache.cache.put(key, value, finiteTtl)
@@ -227,7 +227,7 @@ package object scalacache extends JavaSerializationCodec {
    * @param ttl Time To Live (optional, if not specified then the entry will be cached indefinitely)
    * @tparam V the type of the corresponding value
    */
-  def put[V, Repr](keyParts: Any*)(value: V, ttl: Option[Duration] = None)(implicit scalaCache: ScalaCache[Repr], flags: Flags, codec: Codec[V, Repr]): Future[Unit] =
+  def put[V, Repr](keyParts: Any*)(value: V, ttl: Option[Duration] = None)(implicit scalaCache: ScalaCache[Repr], flags: Flags, codec: Codec[V, Repr]): Future[Any] =
     typed[V, Repr].put(keyParts: _*)(value, ttl)
 
   /**
@@ -238,13 +238,13 @@ package object scalacache extends JavaSerializationCodec {
    *
    * @param keyParts data to be used to generate the cache key. This could be as simple as just a single String. See [[CacheKeyBuilder]].
    */
-  def remove(keyParts: Any*)(implicit scalaCache: ScalaCache[_]): Future[Unit] =
+  def remove(keyParts: Any*)(implicit scalaCache: ScalaCache[_]): Future[Any] =
     scalaCache.cache.remove(toKey(keyParts))
 
   /**
    * Delete the entire contents of the cache. Use wisely!
    */
-  def removeAll()(implicit scalaCache: ScalaCache[_]): Future[Unit] =
+  def removeAll()(implicit scalaCache: ScalaCache[_]): Future[Any] =
     scalaCache.cache.removeAll()
 
   /**

--- a/modules/core/shared/src/test/scala/scalacache/PackageObjectSpec.scala
+++ b/modules/core/shared/src/test/scala/scalacache/PackageObjectSpec.scala
@@ -106,7 +106,7 @@ class PackageObjectSpec extends FlatSpec with Matchers with BeforeAndAfter with 
 
   it should "perform the cache write asynchronously if ScalaCache is thus configured" in {
     val cache = new LoggingMockCache {
-      override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, NoSerialization]): Future[Unit] = {
+      override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, NoSerialization]): Future[Any] = {
         Thread.sleep(2000L)
         super.put(key, value, ttl)
       }

--- a/modules/core/shared/src/test/scala/scalacache/mocks.scala
+++ b/modules/core/shared/src/test/scala/scalacache/mocks.scala
@@ -7,25 +7,25 @@ import scalacache.serialization.{ Codec, InMemoryRepr }
 
 class EmptyCache extends Cache[InMemoryRepr] {
   override def get[V](key: String)(implicit codec: Codec[V, InMemoryRepr]): Future[Option[V]] = Future.successful(None)
-  override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, InMemoryRepr]) = Future.successful((): Unit)
-  override def remove(key: String) = Future.successful((): Unit)
-  override def removeAll() = Future.successful((): Unit)
+  override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, InMemoryRepr]): Future[Any] = Future.successful((): Unit)
+  override def remove(key: String): Future[Any] = Future.successful((): Unit)
+  override def removeAll(): Future[Any] = Future.successful((): Unit)
   override def close(): Unit = {}
 }
 
 class FullCache(value: Any) extends Cache[InMemoryRepr] {
   override def get[V](key: String)(implicit codec: Codec[V, InMemoryRepr]): Future[Option[V]] = Future.successful(Some(value).asInstanceOf[Option[V]])
-  override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, InMemoryRepr]) = Future.successful((): Unit)
-  override def remove(key: String) = Future.successful((): Unit)
-  override def removeAll() = Future.successful((): Unit)
+  override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, InMemoryRepr]): Future[Any] = Future.successful((): Unit)
+  override def remove(key: String): Future[Any] = Future.successful((): Unit)
+  override def removeAll(): Future[Any] = Future.successful((): Unit)
   override def close(): Unit = {}
 }
 
 class FailedFutureReturningCache extends Cache[InMemoryRepr] {
   override def get[V](key: String)(implicit codec: Codec[V, InMemoryRepr]): Future[Option[V]] = Future.failed(new RuntimeException("failed to read"))
-  override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, InMemoryRepr]): Future[Unit] = Future.failed(new RuntimeException("failed to write"))
-  override def remove(key: String) = Future.successful((): Unit)
-  override def removeAll() = Future.successful((): Unit)
+  override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, InMemoryRepr]): Future[Any] = Future.failed(new RuntimeException("failed to write"))
+  override def remove(key: String): Future[Any] = Future.successful((): Unit)
+  override def removeAll(): Future[Any] = Future.successful((): Unit)
   override def close(): Unit = {}
 }
 
@@ -42,13 +42,13 @@ class MockCache extends Cache[InMemoryRepr] {
     Future.successful(value.asInstanceOf[Option[V]])
   }
 
-  def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, InMemoryRepr]) =
+  def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, InMemoryRepr]): Future[Any] =
     Future.successful(mmap.put(key, value))
 
-  def remove(key: String) =
+  def remove(key: String): Future[Any] =
     Future.successful(mmap.remove(key))
 
-  def removeAll() =
+  def removeAll(): Future[Any] =
     Future.successful(mmap.clear())
 
   def close(): Unit = {}
@@ -70,12 +70,12 @@ trait LoggingCache extends Cache[InMemoryRepr] {
     super.get[V](key)
   }
 
-  abstract override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, InMemoryRepr]) = {
+  abstract override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, InMemoryRepr]): Future[Any] = {
     putCalledWithArgs.append((key, value, ttl))
     super.put(key, value, ttl)
   }
 
-  abstract override def remove(key: String) = {
+  abstract override def remove(key: String): Future[Any] = {
     removeCalledWithArgs.append(key)
     super.remove(key)
   }


### PR DESCRIPTION
I use scalacache interface for my custom cache implementation. It abstracts away a lot of boilerplate code. Great work! 
I found small things in the Cache trait that I believe it could be improved, and I'd love to know what you think about it.
```scala
trait Cache[Repr] {
  ...
  def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, Repr]): Future[Unit]
  def remove(key: String): Future[Unit]
  def removeAll(): Future[Unit]
}
```

The return type of put, remove, and removeAll are Future[Unit]. Semantically, Unit is similar to void in Java and they are compatible. The problem is a lot of cache implementations do not return Unit type (or void). They often return Boolean, Integer, or Long.
I implemented the scalacache for rediscala and the following code may illustrate the problem better than my words.

```scala
class MyRediscalaCache(...) {
  import system.dispatcher
 ...
override def put[V](key: String, value: V, ttl: Option[Duration])(implicit codec: Codec[V, Array[Byte]]): Future[Unit] = {
    val valueBytes = codec.serialize(value)
    RedisCache.put(redisClient, key, valueBytes, ttl).map(_ ⇒ ())
  }
  override def remove(key: String): Future[Unit] = {
    RedisCache.remove(redisClient, key).map(_ ⇒ ())
  }
  override def removeAll(): Future[Unit] = {
    RedisCache.removeAll(redisClient).map(_ ⇒ ())
  }
  ...
}
```
When the return type is Future[Unit], I could not return Future[Boolean] or Future[Long]. 
I have to `map` one type to another and it requires ExecutionContext in the scope.
While the computation is cheap, the `map` function uses Promise and ExecutionContext to execute the conversion in a separated thread. If we change the return type of those methods to Future[Any], we can don't have to do `map(_ => ())`.

I don't know how people use this Cache, but this change should not break most people code (unless they create an abstract over an abstract. still in that case, it is an easy fix for them) 
What do you think?


