### PR TITLE
Redis: log cache writes

### DIFF
--- a/modules/redis/src/main/scala/scalacache/redis/RedisCacheBase.scala
+++ b/modules/redis/src/main/scala/scalacache/redis/RedisCacheBase.scala
@@ -67,6 +67,7 @@ trait RedisCacheBase[V] extends AbstractCache[V] {
             jedis.setex(keyBytes, d.toSeconds.toInt, valueBytes)
         }
       }
+      logCachePut(key, ttl)
     }
 
   protected def doRemove[F[_]](key: String)(implicit mode: Mode[F]): F[Any] = mode.M.delay {


### PR DESCRIPTION
This makes the logging in the Redis backend consistent with all the others.