### PR TITLE
Make the underlying caches accessible

### DIFF
--- a/modules/cache2k/src/main/scala/scalacache/cache2k/Cache2kCache.scala
+++ b/modules/cache2k/src/main/scala/scalacache/cache2k/Cache2kCache.scala
@@ -12,7 +12,7 @@ import scalacache.{AbstractCache, CacheConfig, Mode}
  *
  * This cache implementation is synchronous.
  */
-class Cache2kCache[V](underlying: CCache[String, V])(implicit val config: CacheConfig) extends AbstractCache[V] {
+class Cache2kCache[V](val underlying: CCache[String, V])(implicit val config: CacheConfig) extends AbstractCache[V] {
 
   override protected final val logger =
     LoggerFactory.getLogger(getClass.getName)

--- a/modules/caffeine/src/main/scala/scalacache/caffeine/CaffeineCache.scala
+++ b/modules/caffeine/src/main/scala/scalacache/caffeine/CaffeineCache.scala
@@ -15,8 +15,8 @@ import scala.language.higherKinds
  *
  * This cache implementation is synchronous.
  */
-class CaffeineCache[V](underlying: CCache[String, Entry[V]])(implicit val config: CacheConfig,
-                                                             clock: Clock = Clock.systemUTC())
+class CaffeineCache[V](val underlying: CCache[String, Entry[V]])(implicit val config: CacheConfig,
+                                                                 clock: Clock = Clock.systemUTC())
     extends AbstractCache[V] {
 
   override protected final val logger =

--- a/modules/caffeine/src/main/scala/scalacache/caffeine/CaffeineCache.scala
+++ b/modules/caffeine/src/main/scala/scalacache/caffeine/CaffeineCache.scala
@@ -24,12 +24,12 @@ class CaffeineCache[V](underlying: CCache[String, Entry[V]])(implicit val config
 
   def doGet[F[_]](key: String)(implicit mode: Mode[F]): F[Option[V]] = {
     mode.M.delay {
-      val baseValue = underlying.getIfPresent(key)
+      val entry = underlying.getIfPresent(key)
       val result = {
-        if (baseValue != null) {
-          val entry = baseValue.asInstanceOf[Entry[V]]
-          if (entry.isExpired) None else Some(entry.value)
-        } else None
+        if (entry == null || entry.isExpired)
+          None
+        else
+          Some(entry.value)
       }
       logCacheHitOrMiss(key, result)
       result

--- a/modules/ehcache/src/main/scala/scalacache/ehcache/EhcacheCache.scala
+++ b/modules/ehcache/src/main/scala/scalacache/ehcache/EhcacheCache.scala
@@ -11,7 +11,7 @@ import scala.language.higherKinds
 /**
   * Thin wrapper around Ehcache.
   */
-class EhcacheCache[V](underlying: Ehcache)(implicit val config: CacheConfig) extends AbstractCache[V] {
+class EhcacheCache[V](val underlying: Ehcache)(implicit val config: CacheConfig) extends AbstractCache[V] {
 
   override protected final val logger =
     LoggerFactory.getLogger(getClass.getName)

--- a/modules/guava/src/main/scala/scalacache/guava/GuavaCache.scala
+++ b/modules/guava/src/main/scala/scalacache/guava/GuavaCache.scala
@@ -23,12 +23,12 @@ class GuavaCache[V](underlying: GCache[String, Entry[V]])(implicit val config: C
 
   def doGet[F[_]](key: String)(implicit mode: Mode[F]): F[Option[V]] = {
     mode.M.delay {
-      val baseValue = underlying.getIfPresent(key)
+      val entry = underlying.getIfPresent(key)
       val result = {
-        if (baseValue != null) {
-          val entry = baseValue.asInstanceOf[Entry[V]]
-          if (entry.isExpired) None else Some(entry.value)
-        } else None
+        if (entry == null || entry.isExpired)
+          None
+        else
+          Some(entry.value)
       }
       logCacheHitOrMiss(key, result)
       result

--- a/modules/guava/src/main/scala/scalacache/guava/GuavaCache.scala
+++ b/modules/guava/src/main/scala/scalacache/guava/GuavaCache.scala
@@ -14,8 +14,8 @@ import scala.language.higherKinds
 /*
  * Thin wrapper around Google Guava.
  */
-class GuavaCache[V](underlying: GCache[String, Entry[V]])(implicit val config: CacheConfig,
-                                                          clock: Clock = Clock.systemUTC())
+class GuavaCache[V](val underlying: GCache[String, Entry[V]])(implicit val config: CacheConfig,
+                                                              clock: Clock = Clock.systemUTC())
     extends AbstractCache[V] {
 
   override protected final val logger =

--- a/modules/memcached/src/main/scala/scalacache/memcached/MemcachedCache.scala
+++ b/modules/memcached/src/main/scala/scalacache/memcached/MemcachedCache.scala
@@ -17,7 +17,8 @@ class MemcachedException(message: String) extends Exception(message)
 /**
   * Wrapper around spymemcached
   */
-class MemcachedCache[V](client: MemcachedClient, keySanitizer: MemcachedKeySanitizer = ReplaceAndTruncateSanitizer())(
+class MemcachedCache[V](val client: MemcachedClient,
+                        val keySanitizer: MemcachedKeySanitizer = ReplaceAndTruncateSanitizer())(
     implicit val config: CacheConfig,
     codec: Codec[V])
     extends AbstractCache[V]

--- a/modules/ohc/src/main/scala/scalacache/ohc/OhcCache.scala
+++ b/modules/ohc/src/main/scala/scalacache/ohc/OhcCache.scala
@@ -15,7 +15,7 @@ import scalacache.{AbstractCache, CacheConfig, Mode}
  *
  * This cache implementation is synchronous.
  */
-class OhcCache[V](underlying: OHCache[String, V])(implicit val config: CacheConfig) extends AbstractCache[V] {
+class OhcCache[V](val underlying: OHCache[String, V])(implicit val config: CacheConfig) extends AbstractCache[V] {
 
   override protected final val logger =
     LoggerFactory.getLogger(getClass.getName)


### PR DESCRIPTION
Makes the `underlying` constructor parameter a `val` for all implementations.

Also removed some redundant casts that I found.

Ref #186