### PR TITLE
Update cache2k to 1.2.0.Final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,8 +108,8 @@ lazy val redis = module("redis")
 lazy val cache2k = module("cache2k")
   .settings(
     libraryDependencies ++= Seq(
-      "org.cache2k" % "cache2k-core" % "1.0.2.Final",
-      "org.cache2k" % "cache2k-api" % "1.0.2.Final"
+      "org.cache2k" % "cache2k-core" % "1.2.0.Final",
+      "org.cache2k" % "cache2k-api" % "1.2.0.Final"
     )
   )
 


### PR DESCRIPTION
Bumps cache2k from 1.0.2.Final to 1.2.0.Final.
https://github.com/cache2k/cache2k/releases/tag/v1.2.0.Final