### PR TITLE
Remove the implicit for cats-effect IO

### DIFF
--- a/modules/cats-effect/src/main/scala/scalacache/CatsEffect.scala
+++ b/modules/cats-effect/src/main/scala/scalacache/CatsEffect.scala
@@ -10,15 +10,9 @@ object CatsEffect {
   object modes {
 
     /**
-      * A mode that wraps computations in cats-effect IO.
-      */
-    implicit val io: Mode[IO] = new Mode[IO] {
-      val M: Async[IO] = asyncForCatsEffectAsync[IO]
-    }
-
-    /**
       * A mode that wraps computations in F[_],
       * where there is an instance of cats-effect Async available for F.
+      * This includes the cats-effect `IO[_]` type.
       */
     implicit def async[F[_]](implicit F: CatsAsync[F]): Mode[F] = new Mode[F] {
       val M: Async[F] = asyncForCatsEffectAsync[F]

--- a/modules/tests/src/test/scala/integrationtests/IntegrationTests.scala
+++ b/modules/tests/src/test/scala/integrationtests/IntegrationTests.scala
@@ -91,7 +91,7 @@ class IntegrationTests extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     s"$name ⇔ (cats-effect IO)" should "defer the computation and give the correct result" in {
       implicit val theCache: Cache[String] = cache
-      implicit val mode: Mode[CatsIO] = CatsEffect.modes.io
+      implicit val mode: Mode[CatsIO] = CatsEffect.modes.async
 
       val key = UUID.randomUUID().toString
       val initialValue = UUID.randomUUID().toString


### PR DESCRIPTION
It's superseded by the one for Async. It was only left for backwards
compatibility, but it appears to be causing ambiguous implicit problems
for some users.

Fixes #228