### PR TITLE
Use final versions for circe and cats effect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -144,7 +144,7 @@ lazy val ohc = jvmOnlyModule("ohc")
 lazy val catsEffect = jvmOnlyModule("cats-effect")
   .settings(
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-effect" % "2.0.0-M4"
+      "org.typelevel" %% "cats-effect" % "2.0.0"
     ),
     coverageMinimum := 50,
     coverageFailOnMinimum := true
@@ -159,12 +159,20 @@ lazy val scalaz72 = jvmOnlyModule("scalaz72")
     coverageFailOnMinimum := true
   )
 
+def circeVersion(scalaVersion: String) =
+  CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, scalaMajor)) if scalaMajor >= 12 => "0.12.1"
+    case Some((2, scalaMajor)) if scalaMajor >= 11 => "0.11.1"
+    case _ =>
+      throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
+  }
+
 lazy val circe = jvmOnlyModule("circe")
   .settings(
     libraryDependencies ++= Seq(
-      "io.circe" %% "circe-core"    % "0.12.0-M3",
-      "io.circe" %% "circe-parser"  % "0.12.0-M3",
-      "io.circe" %% "circe-generic" % "0.12.0-M3" % Test,
+      "io.circe" %% "circe-core"    % circeVersion(scalaVersion.value),
+      "io.circe" %% "circe-parser"  % circeVersion(scalaVersion.value),
+      "io.circe" %% "circe-generic" % circeVersion(scalaVersion.value) % Test,
       scalacheck
     ),
     coverageMinimum := 80,


### PR DESCRIPTION
Because Circe dropped 2.11 support in 0.12, I'm using 0.11 for Scala 2.11