### PR TITLE
Automate releases using sbt-ci-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ install:
   - make travis-install
 before_script:
   - make travis-run
+
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheckAll scalafmtSbtCheck coverage test
+  - sbt ++$TRAVIS_SCALA_VERSION coverageReport
+
 stages:
   - name: test
   - name: release
@@ -22,20 +27,22 @@ stages:
 jobs:
   include:
     - stage: test
-      name: Run tests
-      script:
-        - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheckAll scalafmtSbtCheck coverage test ++2.12.10 doc/tut
-        - sbt ++$TRAVIS_SCALA_VERSION coverageReport
-    - stage: test
       name: Check formatting
+      scala: 2.13.1
       script:
-        - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheckAll scalafmtSbtCheck
+        - sbt scalafmtCheckAll scalafmtSbtCheck
+    - stage: test
+      name: Compile the docs
+      scala: 2.12.10
+      script:
+        - sbt doc/tut
     - stage: release
       script: sbt ci-release
 cache:
   directories:
     - $HOME/.sbt
     - $HOME/.ivy2
+    - $HOME/.coursier
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete -print
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete -print

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,37 @@ language: scala
 scala:
   - 2.11.12
   - 2.13.1
-  - 2.12.8
+  - 2.12.10
 jdk:
   - openjdk11
 services:
   - memcached
   - redis
+before_install:
+  - git fetch --tags
 install:
   - make travis-install
 before_script:
   - make travis-run
-script:
-  - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheckAll scalafmtSbtCheck coverage test ++2.12.8 doc/tut
-  - sbt ++$TRAVIS_SCALA_VERSION coverageReport
+stages:
+  - name: test
+  - name: release
+    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
+jobs:
+  include:
+    - name: Run tests
+      script:
+        - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheckAll scalafmtSbtCheck coverage test ++2.12.10 doc/tut
+        - sbt ++$TRAVIS_SCALA_VERSION coverageReport
+    - name: Check formatting
+      script:
+        - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheckAll scalafmtSbtCheck
+    - stage: release
+      script: sbt ci-release
 cache:
   directories:
-  - $HOME/.sbt
-  - $HOME/.ivy2
+    - $HOME/.sbt
+    - $HOME/.ivy2
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete -print
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete -print

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - make travis-run
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheckAll scalafmtSbtCheck coverage test
+  - sbt ++$TRAVIS_SCALA_VERSION coverage test
   - sbt ++$TRAVIS_SCALA_VERSION coverageReport
 
 stages:
@@ -29,15 +29,13 @@ jobs:
     - stage: test
       name: Check formatting
       scala: 2.13.1
-      script:
-        - sbt scalafmtCheckAll scalafmtSbtCheck
+      script: sbt ++$TRAVIS_SCALA_VERSION scalafmtCheckAll scalafmtSbtCheck
     - stage: test
       name: Compile the docs
       scala: 2.12.10
-      script:
-        - sbt doc/tut
+      script: sbt ++$TRAVIS_SCALA_VERSION doc/tut
     - stage: release
-      script: sbt ci-release
+      script: sbt ++$TRAVIS_SCALA_VERSION ci-release
 cache:
   directories:
     - $HOME/.sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ jobs:
       scala: 2.12.10
       script: sbt ++$TRAVIS_SCALA_VERSION doc/tut
     - stage: release
-      script: sbt ++$TRAVIS_SCALA_VERSION ci-release
+      scala: 2.13.1
+      script: sbt ci-release
 cache:
   directories:
     - $HOME/.sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,13 @@ stages:
     if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
 jobs:
   include:
-    - name: Run tests
+    - stage: test
+      name: Run tests
       script:
         - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheckAll scalafmtSbtCheck coverage test ++2.12.10 doc/tut
         - sbt ++$TRAVIS_SCALA_VERSION coverageReport
-    - name: Check formatting
+    - stage: test
+      name: Check formatting
       script:
         - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheckAll scalafmtSbtCheck
     - stage: release

--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,20 @@
 import sbtcrossproject.CrossProject
 
-inThisBuild(List(
-  organization := "com.github.cb372",
-  homepage := Some(url("https://github.com/cb372/scalacache")),
-  licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
-  developers := List(
-    Developer(
-      "cb372",
-      "Chris Birchall",
-      "chris.birchall@gmail.com",
-      url("https://twitter.com/cbirchall")
+inThisBuild(
+  List(
+    organization := "com.github.cb372",
+    homepage := Some(url("https://github.com/cb372/scalacache")),
+    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    developers := List(
+      Developer(
+        "cb372",
+        "Chris Birchall",
+        "chris.birchall@gmail.com",
+        url("https://twitter.com/cbirchall")
+      )
     )
   )
-))
+)
 
 scalafmtOnCompile in ThisBuild := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,35 +1,25 @@
-import sbtrelease.ReleaseStateTransformations._
-import xerial.sbt.Sonatype.sonatypeSettings
 import sbtcrossproject.CrossProject
 
-import scala.sys.process.Process
+inThisBuild(List(
+  organization := "com.github.cb372",
+  homepage := Some(url("https://github.com/cb372/scalacache")),
+  licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+  developers := List(
+    Developer(
+      "cb372",
+      "Chris Birchall",
+      "chris.birchall@gmail.com",
+      url("https://twitter.com/cbirchall")
+    )
+  )
+))
 
 scalafmtOnCompile in ThisBuild := true
 
 lazy val root: Project = Project(id = "scalacache", base = file("."))
-  .enablePlugins(ReleasePlugin)
   .settings(
     commonSettings,
-    sonatypeSettings,
-    publishArtifact := false,
-    releaseCrossBuild := true,
-    releaseProcess := Seq[ReleaseStep](
-      checkSnapshotDependencies,
-      inquireVersions,
-      runClean,
-      runTest,
-      setReleaseVersion,
-      updateVersionInDocs,
-      releaseStepTask(tut in doc),
-      commitUpdatedDocFiles,
-      commitReleaseVersion,
-      tagRelease,
-      publishArtifacts,
-      setNextVersion,
-      commitNextVersion,
-      releaseStepCommand("sonatypeReleaseAll"),
-      pushChanges
-    )
+    publishArtifact := false
   )
   .aggregate(
     coreJS,
@@ -240,84 +230,21 @@ lazy val scalacheck = "org.scalacheck" %% "scalacheck" % "1.14.3" % Test
 
 lazy val commonSettings =
   mavenSettings ++
-    scalafmtSettings ++
     Seq(
       organization := "com.github.cb372",
       scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
-      resolvers += Resolver.typesafeRepo("releases"),
-      releasePublishArtifactsAction := PgpKeys.publishSigned.value,
       parallelExecution in Test := false
     )
 
 lazy val mavenSettings = Seq(
-  pomExtra :=
-    <url>https://github.com/cb372/scalacache</url>
-    <licenses>
-      <license>
-        <name>Apache License, Version 2.0</name>
-        <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-        <distribution>repo</distribution>
-      </license>
-    </licenses>
-    <developers>
-      <developer>
-        <id>cb372</id>
-        <name>Chris Birchall</name>
-        <url>https://github.com/cb372</url>
-      </developer>
-    </developers>,
-  publishTo := {
-    val nexus = "https://oss.sonatype.org/"
-    if (version.value.trim.endsWith("SNAPSHOT"))
-      Some("snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("releases" at nexus + "service/local/staging/deploy/maven2")
-  },
-  publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ =>
     false
   }
 )
 
-lazy val updateVersionInDocs = ReleaseStep(action = st => {
-  val extracted      = Project.extract(st)
-  val projectVersion = extracted.get(Keys.version)
-
-  println(s"Updating project version to $projectVersion in the docs")
-
-  val find = Process(Seq("find", "modules/doc/src/main/tut", "-name", "*.md"))
-
-  val sed = Process(
-    Seq("xargs", "sed", "-i", "", "-E", "-e", s"""s/"scalacache-(.*)" % ".*"/"scalacache-\\1" % "$projectVersion"/g""")
-  )
-
-  (find #| sed).!
-
-  st
-})
-
-lazy val commitUpdatedDocFiles = ReleaseStep(action = st => {
-  val extracted      = Project.extract(st)
-  val projectVersion = extracted.get(Keys.version)
-
-  println("Committing docs")
-
-  Process(
-    Seq("git", "commit", "modules/doc/src/main/tut/*", "-m", s"Update project version in docs to $projectVersion")
-  ).!
-
-  st
-})
-
 def scala211OnlyDeps(moduleIDs: ModuleID*) =
   libraryDependencies ++= (scalaBinaryVersion.value match {
     case "2.11" => moduleIDs
     case other  => Nil
   })
-
-lazy val scalafmtSettings = Seq(
-  // work around https://github.com/lucidsoftware/neo-sbt-scalafmt/issues/18
-  sourceDirectories in scalafmt in Compile := (unmanagedSourceDirectories in Compile).value,
-  sourceDirectories in scalafmt in Test := (unmanagedSourceDirectories in Test).value
-)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"                  % "0.3.7")
 addSbtPlugin("com.47deg"          % "sbt-microsites"           % "0.9.7")
-addSbtPlugin("com.jsuereth"       % "sbt-pgp"                  % "2.0.1")
+addSbtPlugin("com.jsuereth"       % "sbt-pgp"                  % "2.0.1") // TODO remove plugins superseded by sbt-ci-release
 addSbtPlugin("com.github.gseitz"  % "sbt-release"              % "1.0.13")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.32")
@@ -9,3 +9,4 @@ addSbtPlugin("org.scoverage"      % "sbt-scoverage"            % "1.6.1")
 addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"             % "3.8.1")
 addSbtPlugin("com.dwijnand"       % "sbt-travisci"             % "1.2.0")
 addSbtPlugin("org.tpolecat"       % "tut-plugin"               % "0.6.13")
+addSbtPlugin("com.geirsson"       % "sbt-ci-release"           % "1.5.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,9 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"                  % "0.3.7")
 addSbtPlugin("com.47deg"          % "sbt-microsites"           % "0.9.7")
-addSbtPlugin("com.jsuereth"       % "sbt-pgp"                  % "2.0.1") // TODO remove plugins superseded by sbt-ci-release
-addSbtPlugin("com.github.gseitz"  % "sbt-release"              % "1.0.13")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.32")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"             % "2.3.1")
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"            % "1.6.1")
-addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"             % "3.8.1")
 addSbtPlugin("com.dwijnand"       % "sbt-travisci"             % "1.2.0")
 addSbtPlugin("org.tpolecat"       % "tut-plugin"               % "0.6.13")
-addSbtPlugin("com.geirsson"       % "sbt-ci-release"           % "1.5.0")
+addSbtPlugin("com.geirsson"       % "sbt-ci-release"           % "1.5.2")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.28.1-SNAPSHOT"


### PR DESCRIPTION
Replaces sbt-release with sbt-ci-release.

On every push to master, SNAPSHOT artifacts will be published to the Sonatype snapshots repo.

Any maintainer can create a proper release simply by pushing a correctly named tag, e.g. `v0.28.1`.

I haven't actually tested that the `sbt ci-release` stage works in Travis, as that only runs on master or when a tag is pushed. I predict there will be a few follow-up pushes straight to master after this PR is merged and everything blows up.

I removed the sbt tasks related to updating the version number in the docs for now, as it would be too fiddly to set up on Travis. It was a pretty hacky solution anyway. I'll come back to this in later PRs when I migrate from tut to mdoc and set up publishing of the microsite from Travis as part of the release process.