### PR TITLE
Upgrade to Cats Effect 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val core =
       libraryDependencies ++= Seq(
         "org.scala-lang" % "scala-reflect" % scalaVersion.value,
         "org.slf4j"      % "slf4j-api"     % "1.7.30",
-        "org.typelevel"  %% "cats-effect"  % "2.1.4",
+        "org.typelevel"  %% "cats-effect"  % "3.0.0-M4",
         "org.scalatest"  %% "scalatest"    % "3.0.9" % Test,
         "org.scalacheck" %% "scalacheck"   % "1.14.3" % Test
       ),

--- a/build.sbt
+++ b/build.sbt
@@ -74,8 +74,9 @@ lazy val redis = createModule("redis")
 lazy val caffeine = createModule("caffeine")
   .settings(
     libraryDependencies ++= Seq(
-      "com.github.ben-manes.caffeine" % "caffeine" % "2.8.7",
-      "com.google.code.findbugs"      % "jsr305"   % "3.0.2" % Provided
+      "com.github.ben-manes.caffeine" % "caffeine"             % "2.8.7",
+      "org.typelevel"                 %% "cats-effect-testkit" % "3.0.0-M4" % Test,
+      "com.google.code.findbugs"      % "jsr305"               % "3.0.2" % Provided
     ),
     coverageMinimum := 80,
     coverageFailOnMinimum := true

--- a/modules/benchmarks/src/main/scala/scalacache/benchmark/CaffeineBenchmark.scala
+++ b/modules/benchmarks/src/main/scala/scalacache/benchmark/CaffeineBenchmark.scala
@@ -15,7 +15,7 @@ import cats.effect.Clock
 @State(Scope.Thread)
 class CaffeineBenchmark {
 
-  implicit val clockSyncIO = Clock.create[SyncIO]
+  implicit val clockSyncIO = Clock[SyncIO]
 
   val underlyingCache                       = Caffeine.newBuilder().build[String, Entry[String]]()
   implicit val cache: Cache[SyncIO, String] = CaffeineCache[SyncIO, String](underlyingCache)

--- a/modules/benchmarks/src/test/scala/scalacache/benchmark/ProfilingMemoize.scala
+++ b/modules/benchmarks/src/test/scala/scalacache/benchmark/ProfilingMemoize.scala
@@ -13,7 +13,7 @@ import cats.effect.Clock
   */
 object ProfilingMemoize extends App {
 
-  implicit val clockSyncIO = Clock.create[SyncIO]
+  implicit val clockSyncIO = Clock[SyncIO]
   val underlyingCache      = Caffeine.newBuilder().build[String, Entry[String]]()
   implicit val cache       = CaffeineCache[SyncIO, String](underlyingCache)
 

--- a/modules/caffeine/src/main/scala/scalacache/caffeine/CaffeineCache.scala
+++ b/modules/caffeine/src/main/scala/scalacache/caffeine/CaffeineCache.scala
@@ -58,7 +58,7 @@ class CaffeineCache[F[_]: Sync, V](val underlying: CCache[String, Entry[V]])(
   }
 
   private def toExpiryTime(ttl: Duration): F[Instant] =
-    clock.monotonic(TimeUnit.MILLISECONDS).map(Instant.ofEpochMilli(_).plusMillis(ttl.toMillis))
+    clock.monotonic.map(m => Instant.ofEpochMilli(m.toMillis).plusMillis(ttl.toMillis))
 
 }
 

--- a/modules/caffeine/src/test/scala/scalacache/caffeine/CaffeineCacheSpec.scala
+++ b/modules/caffeine/src/test/scala/scalacache/caffeine/CaffeineCacheSpec.scala
@@ -2,39 +2,53 @@ package scalacache.caffeine
 
 import java.time.Instant
 
-import scalacache._
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import cats.effect.testkit.TestContext
+import cats.effect.unsafe.{IORuntime, Scheduler}
+import cats.effect.{Clock, IO, Sync, SyncIO}
 import com.github.benmanes.caffeine.cache.Caffeine
-
-import scala.concurrent.duration._
 import org.scalatest.concurrent.ScalaFutures
-import cats.effect.SyncIO
-import cats.effect.Clock
+import org.scalatest.{AsyncFlatSpec, BeforeAndAfter, Matchers}
+import scalacache._
 
-import cats.Applicative
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
-class CaffeineCacheSpec extends FlatSpec with Matchers with BeforeAndAfter with ScalaFutures {
+class CaffeineCacheSpec extends AsyncFlatSpec with Matchers with BeforeAndAfter with ScalaFutures {
+
+  private implicit val deterministicRuntime: (TestContext, IORuntime) = {
+
+    val ctx = TestContext()
+    val scheduler = new Scheduler {
+      def sleep(delay: FiniteDuration, action: Runnable): Runnable = {
+        val cancel = ctx.schedule(delay, action)
+        () => cancel()
+      }
+
+      def nowMillis()      = ctx.now().toMillis
+      def monotonicNanos() = ctx.now().toNanos
+    }
+
+    val runtime = IORuntime(ctx, ctx, scheduler, () => ())
+
+    (ctx, runtime)
+  }
+
+  private implicit val runTime: IORuntime   = deterministicRuntime._2
+  private val ctx: TestContext              = deterministicRuntime._1
+  private implicit val ec: ExecutionContext = ctx.derive()
 
   private def newCCache = Caffeine.newBuilder.build[String, Entry[String]]
 
-  val defaultClock = Clock[SyncIO]
-  def fixedClock(now: Instant): Clock[SyncIO] = new Clock[SyncIO] {
-
-    override def applicative: Applicative[SyncIO] = defaultClock.applicative
-
-    override def realTime: SyncIO[FiniteDuration] = SyncIO.pure {
-      now.toEpochMilli.milliseconds
-    }
-
-    override def monotonic: SyncIO[FiniteDuration] = realTime
+  private def newFCache[F[_]: Sync: Clock, V](
+      underlying: com.github.benmanes.caffeine.cache.Cache[String, Entry[V]]
+  ) = {
+    CaffeineCache[F, V](underlying)
   }
 
-  def newIOCache[V](
-      underlying: com.github.benmanes.caffeine.cache.Cache[String, Entry[V]],
-      clock: Clock[SyncIO] = defaultClock
+  private def newIOCache[V](
+      underlying: com.github.benmanes.caffeine.cache.Cache[String, Entry[V]]
   ) = {
-    implicit val clockImplicit = clock
-    CaffeineCache[SyncIO, V](underlying)
+    newFCache[SyncIO, V](underlying)
   }
 
   behavior of "get"
@@ -43,7 +57,8 @@ class CaffeineCacheSpec extends FlatSpec with Matchers with BeforeAndAfter with 
     val underlying = newCCache
     val entry      = Entry("hello", expiresAt = None)
     underlying.put("key1", entry)
-    newIOCache(underlying).get("key1").unsafeRunSync() should be(Some("hello"))
+    val result = newIOCache(underlying).get("key1").unsafeRunSync()
+    result should be(Some("hello"))
   }
 
   it should "return None if the given key does not exist in the underlying cache" in {
@@ -71,25 +86,28 @@ class CaffeineCacheSpec extends FlatSpec with Matchers with BeforeAndAfter with 
   behavior of "put with TTL"
 
   it should "store the given key-value pair in the underlying cache with the given TTL" in {
-    val now   = Instant.parse("2020-05-31T12:00:00Z")
-    val clock = fixedClock(now)
+    val now = Instant.ofEpochMilli(ctx.now.toMillis)
 
     val underlying = newCCache
-    newIOCache(underlying, clock).put("key1")("hello", Some(10.seconds)).unsafeRunSync()
+    val result = newFCache[IO, String](underlying).put("key1")("hello", Some(10.seconds)).unsafeToFuture().map { _ =>
+      underlying.getIfPresent("key1") should be(Entry("hello", expiresAt = Some(now.plusSeconds(10))))
 
-    underlying.getIfPresent("key1") should be(Entry("hello", expiresAt = Some(now.plusSeconds(10))))
+    }
+    ctx.tick()
+    result
   }
 
   it should "support a TTL greater than Int.MaxValue millis" in {
-    val now   = Instant.parse("2015-10-01T00:00:00Z")
-    val clock = fixedClock(now)
+    val now = Instant.ofEpochMilli(ctx.now.toMillis)
 
     val underlying = newCCache
-    newIOCache(underlying, clock).put("key1")("hello", Some(30.days)).unsafeRunSync()
-
-    underlying.getIfPresent("key1") should be(
-      Entry("hello", expiresAt = Some(Instant.parse("2015-10-31T00:00:00Z")))
-    )
+    val result = newFCache[IO, String](underlying).put("key1")("hello", Some(30.days)).unsafeToFuture().map { _ =>
+      underlying.getIfPresent("key1") should be(
+        Entry("hello", expiresAt = Some(now.plusMillis(30.days.toMillis)))
+      )
+    }
+    ctx.tick()
+    result
   }
 
   behavior of "remove"

--- a/modules/caffeine/src/test/scala/scalacache/caffeine/CaffeineCacheSpec.scala
+++ b/modules/caffeine/src/test/scala/scalacache/caffeine/CaffeineCacheSpec.scala
@@ -10,7 +10,6 @@ import scala.concurrent.duration._
 import org.scalatest.concurrent.ScalaFutures
 import cats.effect.SyncIO
 import cats.effect.Clock
-import java.util.concurrent.TimeUnit
 
 import cats.Applicative
 
@@ -24,7 +23,7 @@ class CaffeineCacheSpec extends FlatSpec with Matchers with BeforeAndAfter with 
     override def applicative: Applicative[SyncIO] = defaultClock.applicative
 
     override def realTime: SyncIO[FiniteDuration] = SyncIO.pure {
-      FiniteDuration(now.toEpochMilli, TimeUnit.MILLISECONDS)
+      now.toEpochMilli.milliseconds
     }
 
     override def monotonic: SyncIO[FiniteDuration] = realTime

--- a/modules/core/src/main/scala/scalacache/Entry.scala
+++ b/modules/core/src/main/scala/scalacache/Entry.scala
@@ -20,7 +20,7 @@ object Entry {
   def isExpired[F[_], A](entry: Entry[A])(implicit clock: Clock[F], applicative: Applicative[F]): F[Boolean] =
     entry.expiresAt
       .traverse { expiration =>
-        val now = clock.monotonic(TimeUnit.MILLISECONDS).map(Instant.ofEpochMilli(_))
+        val now = clock.monotonic.map(m => Instant.ofEpochMilli(m.toMillis))
 
         now.map(expiration.isBefore(_))
       }

--- a/modules/core/src/test/scala/scalacache/mocks.scala
+++ b/modules/core/src/test/scala/scalacache/mocks.scala
@@ -105,17 +105,17 @@ trait LoggingCache[F[_], V] extends AbstractCache[F, V] {
   var (getCalledWithArgs, putCalledWithArgs, removeCalledWithArgs) =
     (ArrayBuffer.empty[String], ArrayBuffer.empty[(String, Any, Option[Duration])], ArrayBuffer.empty[String])
 
-  protected abstract override def doGet(key: String): F[Option[V]] = F.suspend {
+  protected abstract override def doGet(key: String): F[Option[V]] = F.defer {
     getCalledWithArgs.append(key)
     super.doGet(key)
   }
 
-  protected abstract override def doPut(key: String, value: V, ttl: Option[Duration]): F[Unit] = F.suspend {
+  protected abstract override def doPut(key: String, value: V, ttl: Option[Duration]): F[Unit] = F.defer {
     putCalledWithArgs.append((key, value, ttl))
     super.doPut(key, value, ttl)
   }
 
-  protected abstract override def doRemove(key: String): F[Unit] = F.suspend {
+  protected abstract override def doRemove(key: String): F[Unit] = F.defer {
     removeCalledWithArgs.append(key)
     super.doRemove(key)
   }

--- a/modules/docs/src/main/mdoc/docs/cache-implementations.md
+++ b/modules/docs/src/main/mdoc/docs/cache-implementations.md
@@ -97,8 +97,9 @@ Usage:
 import scalacache._
 import scalacache.caffeine._
 import cats.effect.{Clock, IO}
+import cats.effect.unsafe.implicits.global
 
-implicit val clock: Clock[IO] = Clock.create
+implicit val clock: Clock[IO] = Clock[IO]
 
 implicit val caffeineCache: Cache[IO, String] = CaffeineCache[IO, String].unsafeRunSync()
 ```
@@ -110,6 +111,7 @@ import scalacache._
 import scalacache.caffeine._
 import com.github.benmanes.caffeine.cache.Caffeine
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 
 val underlyingCaffeineCache = Caffeine.newBuilder().maximumSize(10000L).build[String, Entry[String]]
 implicit val customisedCaffeineCache: Cache[IO, String] = CaffeineCache(underlyingCaffeineCache)

--- a/modules/docs/src/main/mdoc/docs/flags.md
+++ b/modules/docs/src/main/mdoc/docs/flags.md
@@ -25,6 +25,7 @@ import scalacache.memcached._
 import scalacache.memoization._
 import scalacache.serialization.binary._
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 
 final case class Cat(id: Int, name: String, colour: String)
 

--- a/modules/docs/src/main/mdoc/docs/index.md
+++ b/modules/docs/src/main/mdoc/docs/index.md
@@ -79,6 +79,7 @@ put("foo", 123, "bar")(ericTheCat) // Will be cached with key "foo:123:bar"
 ```
 
 ```scala mdoc:invisible
+import cats.effect.unsafe.implicits.global
 for (cache <- List(catsCache)) {
   cache.close.unsafeRunSync()
 } 

--- a/modules/docs/src/main/mdoc/docs/memoization.md
+++ b/modules/docs/src/main/mdoc/docs/memoization.md
@@ -126,6 +126,7 @@ def doSomething(userId: UserId)(implicit @cacheKeyExclude db: DBConnection): Str
 will only include the `userId` argument's value in its cache keys.
 
 ```scala mdoc:invisible
+import cats.effect.unsafe.implicits.global
 for (cache <- List(catsCache)) {
   cache.close.unsafeRunSync()
 } 

--- a/modules/memcached/src/main/scala/scalacache/memcached/MemcachedCache.scala
+++ b/modules/memcached/src/main/scala/scalacache/memcached/MemcachedCache.scala
@@ -32,7 +32,7 @@ class MemcachedCache[F[_]: Async, V](
     Logger.getLogger[F](getClass.getName)
 
   override protected def doGet(key: String): F[Option[V]] = {
-    F.async { cb =>
+    F.async_ { cb =>
       val f = client.asyncGet(keySanitizer.toValidMemcachedKey(key))
       f.addListener(new GetCompletionListener {
         def onComplete(g: GetFuture[_]): Unit = {
@@ -57,7 +57,7 @@ class MemcachedCache[F[_]: Async, V](
   }
 
   override protected def doPut(key: String, value: V, ttl: Option[Duration]): F[Unit] = {
-    F.async { cb =>
+    F.async_ { cb =>
       val valueToSend = codec.encode(value)
       val f           = client.set(keySanitizer.toValidMemcachedKey(key), toMemcachedExpiry(ttl), valueToSend)
       f.addListener(new OperationCompletionListener {
@@ -75,7 +75,7 @@ class MemcachedCache[F[_]: Async, V](
   }
 
   override protected def doRemove(key: String): F[Unit] = {
-    F.async { cb =>
+    F.async_ { cb =>
       val f = client.delete(key)
       f.addListener(new OperationCompletionListener {
         def onComplete(g: OperationFuture[_]): Unit = {
@@ -89,7 +89,7 @@ class MemcachedCache[F[_]: Async, V](
   }
 
   override protected def doRemoveAll: F[Unit] = {
-    F.async { cb =>
+    F.async_ { cb =>
       val f = client.flush()
       f.addListener(new OperationCompletionListener {
         def onComplete(g: OperationFuture[_]): Unit = {

--- a/modules/memcached/src/test/scala/scalacache/memcached/MemcachedCacheSpec.scala
+++ b/modules/memcached/src/test/scala/scalacache/memcached/MemcachedCacheSpec.scala
@@ -26,7 +26,7 @@ class MemcachedCacheSpec
     client.shutdown()
   }
 
-  import scala.concurrent.ExecutionContext.Implicits.global
+  import cats.effect.unsafe.implicits.global
 
   def memcachedIsRunning = {
     try {

--- a/modules/redis/src/main/scala/scalacache/redis/RedisCache.scala
+++ b/modules/redis/src/main/scala/scalacache/redis/RedisCache.scala
@@ -3,18 +3,20 @@ package scalacache.redis
 import redis.clients.jedis._
 
 import scala.language.higherKinds
-import scalacache.{CacheConfig}
+import scalacache.CacheConfig
 import scalacache.serialization.Codec
-import cats.effect.Resource
-import cats.effect.Sync
+import cats.effect.{MonadCancel, MonadCancelThrow, Resource, Sync}
 
 /**
   * Thin wrapper around Jedis
   */
-class RedisCache[F[_]: Sync, V](val jedisPool: JedisPool)(implicit val config: CacheConfig, val codec: Codec[V])
-    extends RedisCacheBase[F, V] {
+class RedisCache[F[_]: Sync: MonadCancelThrow, V](val jedisPool: JedisPool)(
+    implicit val config: CacheConfig,
+    val codec: Codec[V]
+) extends RedisCacheBase[F, V] {
 
-  protected def F: Sync[F] = Sync[F]
+  protected def F: Sync[F]                             = Sync[F]
+  protected def MonadCancelThrowF: MonadCancelThrow[F] = MonadCancel[F, Throwable]
   type JClient = Jedis
 
   protected val doRemoveAll: F[Unit] = withJedis { jedis =>
@@ -27,14 +29,19 @@ object RedisCache {
   /**
     * Create a Redis client connecting to the given host and use it for caching
     */
-  def apply[F[_]: Sync, V](host: String, port: Int)(implicit config: CacheConfig, codec: Codec[V]): RedisCache[F, V] =
+  def apply[F[_]: Sync: MonadCancelThrow, V](
+      host: String,
+      port: Int
+  )(implicit config: CacheConfig, codec: Codec[V]): RedisCache[F, V] =
     apply(new JedisPool(host, port))
 
   /**
     * Create a cache that uses the given Jedis client pool
     * @param jedisPool a Jedis pool
     */
-  def apply[F[_]: Sync, V](jedisPool: JedisPool)(implicit config: CacheConfig, codec: Codec[V]): RedisCache[F, V] =
+  def apply[F[_]: Sync: MonadCancelThrow, V](
+      jedisPool: JedisPool
+  )(implicit config: CacheConfig, codec: Codec[V]): RedisCache[F, V] =
     new RedisCache[F, V](jedisPool)
 
 }

--- a/modules/redis/src/main/scala/scalacache/redis/RedisClusterCache.scala
+++ b/modules/redis/src/main/scala/scalacache/redis/RedisClusterCache.scala
@@ -20,7 +20,7 @@ class RedisClusterCache[F[_]: Sync, V](val jedisCluster: JedisCluster)(
 
   override protected final val logger = Logger.getLogger(getClass.getName)
 
-  override protected def doGet(key: String): F[Option[V]] = F.suspend {
+  override protected def doGet(key: String): F[Option[V]] = F.defer {
     val bytes = jedisCluster.get(key.utf8bytes)
     val result: Codec.DecodingResult[Option[V]] = {
       if (bytes != null)

--- a/modules/redis/src/test/scala/scalacache/redis/Issue32Spec.scala
+++ b/modules/redis/src/test/scala/scalacache/redis/Issue32Spec.scala
@@ -5,6 +5,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scalacache.memoization._
 import scalacache.serialization.binary._
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 
 case class User(id: Int, name: String)
 

--- a/modules/redis/src/test/scala/scalacache/redis/RedisCacheSpecBase.scala
+++ b/modules/redis/src/test/scala/scalacache/redis/RedisCacheSpecBase.scala
@@ -8,7 +8,7 @@ import scalacache.serialization.Codec.DecodingResult
 import scalacache.serialization.binary._
 import scalacache.serialization.{Codec, FailedToDecode}
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import cats.effect.unsafe.implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.postfixOps

--- a/modules/tests/src/test/scala/integrationtests/IntegrationTests.scala
+++ b/modules/tests/src/test/scala/integrationtests/IntegrationTests.scala
@@ -7,8 +7,6 @@ import cats.effect.{IO => CatsIO}
 import net.spy.memcached.{AddrUtil, MemcachedClient}
 import redis.clients.jedis.JedisPool
 
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
 import scala.language.higherKinds
 import scala.util.control.NonFatal
 import scalacache._
@@ -16,10 +14,11 @@ import scalacache.caffeine.CaffeineCache
 import scalacache.memcached.MemcachedCache
 import scalacache.redis.RedisCache
 import cats.effect.Clock
+import cats.effect.unsafe.implicits.global
 
 class IntegrationTests extends FlatSpec with Matchers with BeforeAndAfterAll {
 
-  implicit val catsClock: Clock[CatsIO] = Clock.create
+  implicit val catsClock: Clock[CatsIO] = Clock[CatsIO]
 
   private val memcachedClient = new MemcachedClient(AddrUtil.getAddresses("localhost:11211"))
   private val jedisPool       = new JedisPool("localhost", 6379)


### PR DESCRIPTION
Main changes are:
  - supporting Clock w/o direct Applicative
  - updating async to async_
  - handling Sync usages that also required MonadError (now MonadCancel is needed in most cases)
  - import implicit unsafe IORuntime in tests
  - Update suspend to defer where applicable

Resolves #450
