### PR TITLE
abstract cache extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,16 @@
 .idea
+.bloop
+.history
+.metals
+.bsp
+.vscode
 .idea_modules
+metals.sbt
 *.iml
 *.ipr
 *.jfr
+*.class
+*.cache
 target
 coveralls-token.txt
 /*.html

--- a/modules/core/src/main/scala/scalacache/AbstractCache.scala
+++ b/modules/core/src/main/scala/scalacache/AbstractCache.scala
@@ -9,6 +9,8 @@ import cats.MonadError
 import cats.effect.Sync
 import cats.Applicative
 
+import scala.language.implicitConversions
+
 /** An abstract implementation of [[CacheAlg]] that takes care of some things that are common across all concrete
   * implementations.
   *
@@ -139,5 +141,12 @@ trait AbstractCache[F[_], V] extends Cache[F, V] with LoggingSupport[F] {
 
   private def toKey(keyParts: Any*): String =
     config.cacheKeyBuilder.toCacheKey(keyParts)
+
+}
+
+object AbstractCache {
+
+  implicit def abstractCacheOps[F[_]: Monad, V](cache: AbstractCache[F, V]): AbstractCacheOps[F, V] =
+    new AbstractCacheOps(cache)
 
 }

--- a/modules/core/src/main/scala/scalacache/AbstractCacheOps.scala
+++ b/modules/core/src/main/scala/scalacache/AbstractCacheOps.scala
@@ -1,0 +1,140 @@
+package scalacache
+
+import scala.concurrent.duration.Duration
+
+import scala.language.higherKinds
+import cats.Monad
+import cats.syntax.all._
+import cats.MonadError
+import cats.effect.Sync
+import cats.Applicative
+
+/** Extension methods for an AbstractCache. *
+  */
+class AbstractCacheOps[F[_]: Monad, V](underlying: AbstractCache[F, V]) {
+
+  /** Get a value from the cache if it exists. Otherwise compute it, insert it into the cache if the computed value is
+    * Right, and return it.
+    *
+    * @param keyParts
+    *   The cache key
+    * @param ttl
+    *   The time-to-live to use when inserting into the cache. The cache entry will expire after this time has elapsed.
+    * @param f
+    *   A block that computes the Either of value
+    * @param flags
+    *   Flags used to conditionally alter the behaviour of ScalaCache
+    * @return
+    *   The value, either retrieved from the cache or computed
+    */
+  def cachingRight[A](
+      keyParts: Any*
+  )(
+      ttl: Option[Duration] = None
+  )(
+      f: => Either[A, V]
+  )(implicit flags: Flags): F[Either[A, V]] = {
+    underlying.get(keyParts: _*).flatMap {
+      case None =>
+        f match {
+          case Right(v) => underlying.put(keyParts: _*)(v, ttl).map(_ => v.asRight[A])
+          case Left(a)  => a.asLeft[V].pure
+        }
+      case Some(v) => v.asRight[A].pure
+    }
+  }
+
+  /** Get a value from the cache if it exists. Otherwise compute it, insert it into the cache if the computed value is
+    * Some, and return it.
+    *
+    * @param keyParts
+    *   The cache key
+    * @param ttl
+    *   The time-to-live to use when inserting into the cache. The cache entry will expire after this time has elapsed.
+    * @param f
+    *   A block that computes the optional value
+    * @param flags
+    *   Flags used to conditionally alter the behaviour of ScalaCache
+    * @return
+    *   The value, either retrieved from the cache or computed
+    */
+  def cachingSome(
+      keyParts: Any*
+  )(
+      ttl: Option[Duration] = None
+  )(
+      f: => Option[V]
+  )(implicit flags: Flags): F[Option[V]] = {
+    underlying.get(keyParts: _*).flatMap {
+      case None =>
+        f match {
+          case Some(v) => underlying.put(keyParts: _*)(v, ttl).map(_ => v.some)
+          case None    => Option.empty[V].pure
+        }
+      case Some(v) => v.some.pure
+    }
+  }
+
+  /** Get a value from the cache if it exists. Otherwise compute it, insert it into the cache if the computed value is
+    * Right, and return it.
+    *
+    * @param keyParts
+    *   The cache key
+    * @param ttl
+    *   The time-to-live to use when inserting into the cache. The cache entry will expire after this time has elapsed.
+    * @param f
+    *   A block that computes the Either of value wrapped in a container
+    * @param flags
+    *   Flags used to conditionally alter the behaviour of ScalaCache
+    * @return
+    *   The value, either retrieved from the cache or computed
+    */
+  def cachingRightF[A](
+      keyParts: Any*
+  )(
+      ttl: Option[Duration] = None
+  )(
+      f: F[Either[A, V]]
+  )(implicit flags: Flags): F[Either[A, V]] = {
+    underlying.get(keyParts: _*).flatMap {
+      case None =>
+        f.flatMap {
+          case Right(v) => underlying.put(keyParts: _*)(v, ttl).map(_ => v.asRight[A])
+          case Left(a)  => a.asLeft[V].pure
+        }
+      case Some(v) => v.asRight[A].pure
+    }
+  }
+
+  /** Get a value from the cache if it exists. Otherwise compute it, insert it into the cache if the computed value is
+    * Some, and return it.
+    *
+    * @param keyParts
+    *   The cache key
+    * @param ttl
+    *   The time-to-live to use when inserting into the cache. The cache entry will expire after this time has elapsed.
+    * @param f
+    *   A block that computes the optional value wrapped in a container
+    * @param flags
+    *   Flags used to conditionally alter the behaviour of ScalaCache
+    * @return
+    *   The value, either retrieved from the cache or computed
+    */
+  def cachingSomeF(
+      keyParts: Any*
+  )(
+      ttl: Option[Duration] = None
+  )(
+      f: F[Option[V]]
+  )(implicit flags: Flags): F[Option[V]] = {
+    underlying.get(keyParts: _*).flatMap {
+      case None =>
+        f.flatMap {
+          case Some(v) => underlying.put(keyParts: _*)(v, ttl).map(_ => v.some)
+          case None    => Option.empty[V].pure
+        }
+      case Some(v) => v.some.pure
+    }
+  }
+
+}

--- a/modules/core/src/test/scala/scalacache/AbstractCacheOpsSpec.scala
+++ b/modules/core/src/test/scala/scalacache/AbstractCacheOpsSpec.scala
@@ -1,0 +1,109 @@
+package scalacache
+
+import org.scalatest.BeforeAndAfter
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+import scala.util.{Success, Try}
+import cats.effect.SyncIO
+import cats.syntax.all._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AbstractCacheOpsSpec extends AnyFlatSpec with Matchers with BeforeAndAfter {
+
+  val cache = new LoggingMockCache[SyncIO, String]
+
+  before {
+    cache.mmap.clear()
+    cache.reset.unsafeRunSync()
+  }
+
+  behavior of "#cachingRight"
+
+  it should "run the block and cache its Right result with no TTL" in {
+    val effect = cache
+      .cachingRight("myKey")(None) {
+        "result of block".asRight[Other]
+      } *>
+      cache
+        .cachingRight("myKey")(None) {
+          "result of block".asRight[Other]
+        }
+
+    val result = effect.unsafeRunSync()
+
+    cache.getCalledWithArgs.length shouldBe 2
+    cache.getCalledWithArgs(0) should be("myKey")
+    cache.getCalledWithArgs(1) should be("myKey")
+    cache.putCalledWithArgs.length shouldBe 1
+    cache.putCalledWithArgs(0) should be("myKey", "result of block", None)
+    result should be("result of block".asRight[Other])
+  }
+
+  it should "run the block and not cache its Left result" in {
+    val effect = cache
+      .cachingRight("myKey")(None) {
+        Other("error").asLeft[String]
+      } *>
+      cache
+        .cachingRight("myKey")(None) {
+          "result of block".asRight[Other]
+        }
+
+    val result = effect.unsafeRunSync()
+
+    cache.getCalledWithArgs.length shouldBe 2
+    cache.getCalledWithArgs(0) should be("myKey")
+    cache.getCalledWithArgs(1) should be("myKey")
+    cache.putCalledWithArgs.length shouldBe 1
+    cache.putCalledWithArgs(0) should be("myKey", "result of block", None)
+    result should be("result of block".asRight[Other])
+  }
+
+  behavior of "#cachingSome"
+
+  it should "run the block and cache its Some result with no TTL" in {
+    val effect = cache
+      .cachingSome("myKey")(None) {
+        "result of block".some
+      } *>
+      cache
+        .cachingSome("myKey")(None) {
+          "result of block".some
+        }
+
+    val result = effect.unsafeRunSync()
+
+    cache.getCalledWithArgs.length shouldBe 2
+    cache.getCalledWithArgs(0) should be("myKey")
+    cache.getCalledWithArgs(1) should be("myKey")
+    cache.putCalledWithArgs.length shouldBe 1
+    cache.putCalledWithArgs(0) should be("myKey", "result of block", None)
+    result should be("result of block".some)
+  }
+
+  it should "run the block and not cache its None result" in {
+    val effect = cache
+      .cachingSome("myKey")(None) {
+        None
+      } *>
+      cache
+        .cachingSome("myKey")(None) {
+          "result of block".some
+        }
+
+    val result = effect.unsafeRunSync()
+
+    cache.getCalledWithArgs.length shouldBe 2
+    cache.getCalledWithArgs(0) should be("myKey")
+    cache.getCalledWithArgs(1) should be("myKey")
+    cache.putCalledWithArgs.length shouldBe 1
+    cache.putCalledWithArgs(0) should be("myKey", "result of block", None)
+    result should be("result of block".some)
+  }
+
+}
+
+case class Other(s: String)


### PR DESCRIPTION
A few extension methods for the `AbstractCache` for conditional caching.

The methods are similar to `caching` / `cachingF`, but instead of a block/effect with a value they accept a block/effect with an `Option` or `Either` with the value. The computed value is cached only if its `Some` / `Right`. 

The computed value is returned as `Option` / `Either`.

* `cachingRight`
* `cachingSome`
* `cachingRightF`
* `cachingSomeF`

There is a non-zero probability that better names exist for these methods :).

Also, instead of employing the extension methods, these can be defined directly in the `CacheAlg`. I wanted this PR to be less intrusive, but I'm open to suggestions.

WDYT?