### PR TITLE
Update Publish to use sbt-spiewak Tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,10 @@ on:
     tags: [v*]
 
 env:
-  PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-  SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-  PGP_SECRET: ${{ secrets.PGP_SECRET }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+  PGP_SECRET: ${{ secrets.PGP_SECRET }}
 
 jobs:
   build:
@@ -28,7 +27,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.7, 2.12.15, 3.1.0]
-        java: [openjdk@1.11.0]
+        java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -62,20 +61,14 @@ jobs:
       - name: Setup Dependencies
         run: docker-compose up -d
 
-      - name: Run Tests
-        run: sbt ++${{ matrix.scala }} test
+      - name: Run ci task from sbt-spiewak
+        run: sbt ++${{ matrix.scala }} ci
 
       - name: Compile Docs
         run: sbt ++${{ matrix.scala }} docs/mdoc
 
-      - name: Compile Benchmarks
-        run: sbt ++${{ matrix.scala }} benchmarks/compile
-
-      - name: Check Binary Compat
-        run: sbt ++${{ matrix.scala }} mimaReportBinaryIssues
-
       - name: Compress target directories
-        run: tar cf targets.tar modules/benchmarks/target target modules/docs/target modules/tests/target modules/caffeine/target modules/memcached/target modules/circe/target modules/redis/target modules/core/target project/target
+        run: tar cf targets.tar target modules/docs/target modules/tests/target modules/caffeine/target modules/memcached/target modules/circe/target modules/redis/target modules/core/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v2
@@ -86,12 +79,12 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master')
     strategy:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.7]
-        java: [openjdk@1.11.0]
+        java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -146,6 +139,7 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - uses: olafurpg/setup-gpg@v3
+      - name: Import signing key
+        run: echo $PGP_SECRET | base64 -d | gpg --import
 
-      - run: sbt ++${{ matrix.scala }} ci-release
+      - run: sbt ++${{ matrix.scala }} release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.7, 2.12.15, 3.1.0]
-        java: [adopt@1.8]
+        java: [openjdk@1.11.0]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -84,7 +84,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.7]
-        java: [adopt@1.8]
+        java: [openjdk@1.11.0]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)

--- a/build.sbt
+++ b/build.sbt
@@ -136,6 +136,7 @@ lazy val docs = createModule("docs")
 lazy val benchmarks = createModule("benchmarks")
   .enablePlugins(JmhPlugin)
   .settings(
+    githubWorkflowArtifactUpload := false,
     publishArtifact        := false,
     fork in (Compile, run) := true,
     javaOptions in Jmh ++= Seq("-server", "-Xms2G", "-Xmx2G", "-XX:+UseG1GC", "-XX:-UseBiasedLocking"),
@@ -176,29 +177,14 @@ lazy val mavenSettings = Seq(
 val Scala30  = "3.1.0"
 val Scala213 = "2.13.7"
 val Scala212 = "2.12.15"
-val Jdk11    = "openjdk@1.11.0"
 
-ThisBuild / scalaVersion               := Scala213
-ThisBuild / crossScalaVersions         := Seq(Scala213, Scala212, Scala30)
-ThisBuild / githubWorkflowJavaVersions := Seq(Jdk11)
+ThisBuild / scalaVersion        := Scala213
+ThisBuild / crossScalaVersions  := Seq(Scala213, Scala212, Scala30)
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(List("scalafmtCheckAll"), name = Some("Check Formatting")),
   WorkflowStep.Run(List("docker-compose up -d"), name = Some("Setup Dependencies")),
-  WorkflowStep.Sbt(List("test"), name = Some("Run Tests")),
-  WorkflowStep.Sbt(List("docs/mdoc"), name = Some("Compile Docs")),
-  WorkflowStep.Sbt(List("benchmarks/compile"), name = Some("Compile Benchmarks")),
-  WorkflowStep.Sbt(List("mimaReportBinaryIssues"), name = Some("Check Binary Compat"))
+  WorkflowStep.Sbt(List("ci"), name = Some("Run ci task from sbt-spiewak")),
+  WorkflowStep.Sbt(List("docs/mdoc"), name = Some("Compile Docs"))
 )
-//sbt-ci-release settings
-ThisBuild / githubWorkflowPublishTargetBranches := Seq(
-  RefPredicate.Equals(Ref.Branch("master")),
-  RefPredicate.StartsWith(Ref.Tag("v"))
-)
-ThisBuild / githubWorkflowPublishPreamble := Seq(WorkflowStep.Use(UseRef.Public("olafurpg", "setup-gpg", "v3")))
-ThisBuild / githubWorkflowPublish         := Seq(WorkflowStep.Sbt(List("ci-release")))
-ThisBuild / githubWorkflowEnv ++= List("PGP_PASSPHRASE", "PGP_SECRET", "SONATYPE_PASSWORD", "SONATYPE_USERNAME").map {
-  envKey =>
-    envKey -> s"$${{ secrets.$envKey }}"
-}.toMap
 ThisBuild / spiewakCiReleaseSnapshots := true
 ThisBuild / spiewakMainBranches := Seq("master")

--- a/build.sbt
+++ b/build.sbt
@@ -177,10 +177,12 @@ lazy val mavenSettings = Seq(
 val Scala30  = "3.1.0"
 val Scala213 = "2.13.7"
 val Scala212 = "2.12.15"
+val Jdk11    = "openjdk@1.11.0"
 
-ThisBuild / scalaVersion        := Scala213
-ThisBuild / crossScalaVersions  := Seq(Scala213, Scala212, Scala30)
-ThisBuild / githubWorkflowBuild := Seq(
+ThisBuild / scalaVersion               := Scala213
+ThisBuild / crossScalaVersions         := Seq(Scala213, Scala212, Scala30)
+ThisBuild / githubWorkflowJavaVersions := Seq(Jdk11)
+ThisBuild / githubWorkflowBuild        := Seq(
   WorkflowStep.Sbt(List("scalafmtCheckAll"), name = Some("Check Formatting")),
   WorkflowStep.Run(List("docker-compose up -d"), name = Some("Setup Dependencies")),
   WorkflowStep.Sbt(List("ci"), name = Some("Run ci task from sbt-spiewak")),


### PR DESCRIPTION
When I pushed #608 to the main branch, I didn't realize that I didn't yet update the settings inside of the build.sbt for generating the GitHub actions yml files 🤦. As such, this PR updates the GH actions yml to take advantage of the tasks provided by sbt-spiewak.