### PR TITLE
Add support for MongoDB as a cache implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,10 @@ logs
 .ensime
 .ensime_lucene
 .ensime_cache
+.bloop/
 .bsp/
+.metals/
+.vscode/
+target/
+metals.sbt
+*.worksheet.sc

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ logs
 .ensime
 .ensime_lucene
 .ensime_cache
+.bsp/

--- a/build.sbt
+++ b/build.sbt
@@ -128,7 +128,7 @@ lazy val circe = createModule("circe")
   )
 
 lazy val tests = createModule("tests")
-  .settings(publishArtifact := false)
+  .settings(publishArtifact := false, libraryDependencies += "org.mongodb" % "mongodb-driver-sync" % "4.4.1" % Test)
   .dependsOn(caffeine, memcached, redis, circe, mongo, mongoCirce)
 
 lazy val docs = createModule("docs")

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,8 @@ lazy val root: Project = Project(id = "scalacache", base = file("."))
     redis,
     caffeine,
     circe,
-    tests
+    tests,
+    mongo
   )
 
 lazy val core =
@@ -69,6 +70,15 @@ lazy val memcached = createModule("memcached")
   .settings(
     libraryDependencies ++= Seq(
       "net.spy" % "spymemcached" % "2.12.3"
+    )
+  )
+
+
+lazy val mongo = createModule("mongo")
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.mongodb" % "mongodb-driver-sync" % "4.4.1" % Test,
+      "org.mongodb.scala" %% "mongo-scala-driver" % "4.4.1"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,9 @@ inThisBuild(
   )
 )
 
-val CatsEffectVersion = "3.3.5"
-val CirceVersion      = "0.14.1"
+val CatsEffectVersion  = "3.3.5"
+val CirceVersion       = "0.14.1"
+val MongoDriverVersion = "4.5.0"
 
 scalafmtOnCompile in ThisBuild := true
 
@@ -78,8 +79,8 @@ lazy val memcached = createModule("memcached")
 lazy val mongo = createModule("mongo")
   .settings(
     libraryDependencies ++= Seq(
-      "org.mongodb"        % "mongodb-driver-sync" % "4.4.1" % Test,
-      "org.mongodb.scala" %% "mongo-scala-driver"  % "4.4.1"
+      "org.mongodb.scala" %% "mongo-scala-driver"  % MongoDriverVersion,
+      "org.mongodb"        % "mongodb-driver-sync" % MongoDriverVersion % Test
     )
   )
 
@@ -128,7 +129,12 @@ lazy val circe = createModule("circe")
   )
 
 lazy val tests = createModule("tests")
-  .settings(publishArtifact := false, libraryDependencies += "org.mongodb" % "mongodb-driver-sync" % "4.4.1" % Test)
+  .settings(
+    publishArtifact := false,
+    libraryDependencies ++= Seq(
+      "org.mongodb" % "mongodb-driver-sync" % MongoDriverVersion % Test
+    )
+  )
   .dependsOn(caffeine, memcached, redis, circe, mongo, mongoCirce)
 
 lazy val docs = createModule("docs")

--- a/build.sbt
+++ b/build.sbt
@@ -79,8 +79,8 @@ lazy val memcached = createModule("memcached")
 lazy val mongo = createModule("mongo")
   .settings(
     libraryDependencies ++= Seq(
-      "org.mongodb.scala" %% "mongo-scala-driver"  % MongoDriverVersion,
-      "org.mongodb"        % "mongodb-driver-sync" % MongoDriverVersion % Test
+      "org.mongodb" % "mongodb-driver-reactivestreams" % MongoDriverVersion,
+      "org.mongodb" % "mongodb-driver-sync"            % MongoDriverVersion % Test
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,9 @@ lazy val docs = createModule("docs")
     memcached,
     redis,
     caffeine,
-    circe
+    circe,
+    mongo,
+    mongoCirce
   )
 
 lazy val benchmarks = createModule("benchmarks")

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ inThisBuild(
 )
 
 val CatsEffectVersion = "3.3.5"
+val CirceVersion      = "0.14.1"
 
 scalafmtOnCompile in ThisBuild := true
 
@@ -34,7 +35,8 @@ lazy val root: Project = Project(id = "scalacache", base = file("."))
     caffeine,
     circe,
     tests,
-    mongo
+    mongo,
+    mongoCirce
   )
 
 lazy val core =
@@ -76,10 +78,21 @@ lazy val memcached = createModule("memcached")
 lazy val mongo = createModule("mongo")
   .settings(
     libraryDependencies ++= Seq(
-      "org.mongodb" % "mongodb-driver-sync" % "4.4.1" % Test,
-      "org.mongodb.scala" %% "mongo-scala-driver" % "4.4.1"
+      "org.mongodb"        % "mongodb-driver-sync" % "4.4.1" % Test,
+      "org.mongodb.scala" %% "mongo-scala-driver"  % "4.4.1"
     )
   )
+
+lazy val mongoCirce = createModule("mongo-circe")
+  .settings(
+    libraryDependencies ++= Seq(
+      "io.circe" %% "circe-core"    % CirceVersion,
+      "io.circe" %% "circe-generic" % CirceVersion % Test,
+      scalacheck,
+      scalatestplus
+    )
+  )
+  .dependsOn(mongo)
 
 lazy val redis = createModule("redis")
   .settings(
@@ -104,9 +117,9 @@ lazy val caffeine = createModule("caffeine")
 lazy val circe = createModule("circe")
   .settings(
     libraryDependencies ++= Seq(
-      "io.circe" %% "circe-core"    % "0.14.1",
-      "io.circe" %% "circe-parser"  % "0.14.1",
-      "io.circe" %% "circe-generic" % "0.14.1" % Test,
+      "io.circe" %% "circe-core"    % CirceVersion,
+      "io.circe" %% "circe-parser"  % CirceVersion,
+      "io.circe" %% "circe-generic" % CirceVersion % Test,
       scalacheck,
       scalatestplus
     ),
@@ -116,7 +129,7 @@ lazy val circe = createModule("circe")
 
 lazy val tests = createModule("tests")
   .settings(publishArtifact := false)
-  .dependsOn(caffeine, memcached, redis, circe)
+  .dependsOn(caffeine, memcached, redis, circe, mongo, mongoCirce)
 
 lazy val docs = createModule("docs")
   .enablePlugins(MicrositesPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,6 @@ lazy val memcached = createModule("memcached")
     )
   )
 
-
 lazy val mongo = createModule("mongo")
   .settings(
     libraryDependencies ++= Seq(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,7 @@ services:
       image: memcached:latest
       ports:
         - '11211:11211'
+    mongo:
+      image: mongo:4.0
+      ports:
+        - '27017-27019:27017-27019'

--- a/modules/core/src/main/scala/scalacache/serialization/Codec.scala
+++ b/modules/core/src/main/scala/scalacache/serialization/Codec.scala
@@ -29,7 +29,7 @@ trait Decoder[L, R] {
 
 /** Represents a type class that needs to be implemented for serialization/deserialization to work.
   */
-@implicitNotFound(msg = """Could not find any Codecs for types ${L}, ${R}.
+@implicitNotFound(msg = """Could not find any Codec to serialize type ${L} as ${R}.
 If you would like to serialize values in a binary format, please import the binary codec:
 
 import scalacache.serialization.binary._
@@ -41,6 +41,14 @@ import scalacache.serialization.circe._
 import io.circe.generic.auto._
 
 You will need a dependency on the scalacache-circe module.
+
+If you would like to serialize values as MongoDB BSON using circe, please import the circe codec
+and provide a circe Encoder[${L}] and Decoder[${L}], e.g.:
+
+import scalacache.serialization.bson.circe._
+import io.circe.generic.auto._
+
+You will need a dependency on the scalacache-mongo-circe module.
 
 See the documentation for more details on codecs.""")
 trait Codec[L, R] extends Encoder[L, R] with Decoder[L, R] {

--- a/modules/core/src/main/scala/scalacache/serialization/Codec.scala
+++ b/modules/core/src/main/scala/scalacache/serialization/Codec.scala
@@ -29,7 +29,7 @@ trait Decoder[L, R] {
 
 /** Represents a type class that needs to be implemented for serialization/deserialization to work.
   */
-@implicitNotFound(msg = """Could not find any Codecs for types ${L, R}.
+@implicitNotFound(msg = """Could not find any Codecs for types ${L}, ${R}.
 If you would like to serialize values in a binary format, please import the binary codec:
 
 import scalacache.serialization.binary._

--- a/modules/docs/src/main/mdoc/docs/cache-implementations.md
+++ b/modules/docs/src/main/mdoc/docs/cache-implementations.md
@@ -161,7 +161,7 @@ implicit val customisedCaffeineCache: Cache[IO, String, String] = CaffeineCache(
 ```
 
 ```scala mdoc:invisible
-for (cache <- List(redisCache, customisedRedisCache, memcachedCache, customisedMemcachedCache)) {
+for (cache <- List(redisCache, customisedRedisCache, mongoCache, customClientMongoCache, memcachedCache, customisedMemcachedCache)) {
   cache.close.unsafeRunSync()
 }
 ```

--- a/modules/docs/src/main/mdoc/docs/serialization.md
+++ b/modules/docs/src/main/mdoc/docs/serialization.md
@@ -50,7 +50,7 @@ implicit val catDecoder: Decoder[Cat] = deriveDecoder[Cat]
 
 For more information, please consult the [circe docs](https://circe.github.io/circe/).
 
-### BSON Codec
+### BSON codec
 
 If you are using the MongoDB cache implementation, you must provide a `BsonCodec` for serializing your data as BSON.
 

--- a/modules/docs/src/main/mdoc/docs/serialization.md
+++ b/modules/docs/src/main/mdoc/docs/serialization.md
@@ -50,6 +50,41 @@ implicit val catDecoder: Decoder[Cat] = deriveDecoder[Cat]
 
 For more information, please consult the [circe docs](https://circe.github.io/circe/).
 
+### BSON Codec
+
+If you are using the MongoDB cache implementation, you must provide a `BsonCodec` for serializing your data as BSON.
+
+You can do this manually, or use the ScalaCache integration module which converts [circe](https://circe.github.io/circe/) JSON into BSON.
+
+To do the latter you can add a dependency on the scalacache-mongo-circe module:
+
+```
+libraryDependencies += "com.github.cb372" %% "scalacache-mongo-circe" % "0.28.0"
+```
+
+Then import the codec:
+
+```scala mdoc:fail:silent
+import scalacache.serialization.bson.circe._
+```
+
+As with the circe JSON integration, if your cache holds values of type `Cat`, you will also need a Circe `Encoder[Cat]` and `Decoder[Cat]` in implicit scope. The easiest way to do this is to ask circe to automatically derive them:
+
+```scala
+import io.circe.generic.auto._
+```
+
+but if you are worried about performance, it's better to derive them semi-automatically:
+
+```scala
+import io.circe._
+import io.circe.generic.semiauto._
+implicit val catEncoder: Encoder[Cat] = deriveEncoder[Cat]
+implicit val catDecoder: Decoder[Cat] = deriveDecoder[Cat]
+```
+
+For more information, please consult the [circe docs](https://circe.github.io/circe/).
+
 ### Custom Codec
 
 If you want to use a custom `Codec` for your object of type `A`, simply implement an instance of `Codec[A]` and make sure it

--- a/modules/docs/src/main/mdoc/index.md
+++ b/modules/docs/src/main/mdoc/index.md
@@ -14,6 +14,7 @@ Use ScalaCache to add caching to any Scala app with the minimum of fuss.
 The following cache implementations are supported, and it's easy to plugin your own implementation:
 * Memcached
 * Redis
+* MongoDB
 * [Caffeine](https://github.com/ben-manes/caffeine)
 
 ## Compatibility

--- a/modules/mongo-circe/src/main/scala/scalacache/serialization/bson/circe.scala
+++ b/modules/mongo-circe/src/main/scala/scalacache/serialization/bson/circe.scala
@@ -37,6 +37,16 @@ import scala.jdk.CollectionConverters._
 package object circe extends BsonCirceCodec
 
 trait BsonCirceCodec {
+  implicit def scalaCacheBsonEncoderFromCirceEncoder[A](implicit
+      encoder: io.circe.Encoder[A]
+  ): BsonEncoder[A] =
+    new BsonEncoder[A] {
+      override def encode(value: A): BsonValue = {
+        val json = encoder(value)
+        jsonToBson(json)
+      }
+    }
+
   implicit def scalaCacheBsonCodecFromCirceCodec[A](implicit
       encoder: io.circe.Encoder[A],
       decoder: io.circe.Decoder[A]

--- a/modules/mongo-circe/src/main/scala/scalacache/serialization/bson/circe.scala
+++ b/modules/mongo-circe/src/main/scala/scalacache/serialization/bson/circe.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021 scalacache
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scalacache.serialization.bson
+
+import io.circe.Json
+import io.circe.JsonNumber
+import io.circe.JsonObject
+import org.bson.BsonArray
+import org.bson.BsonBoolean
+import org.bson.BsonDecimal128
+import org.bson.BsonDocument
+import org.bson.BsonDouble
+import org.bson.BsonInt32
+import org.bson.BsonInt64
+import org.bson.BsonNull
+import org.bson.BsonString
+import org.bson.BsonValue
+import scalacache.serialization.Codec
+import scalacache.serialization.FailedToDecode
+
+import scala.jdk.CollectionConverters._
+
+package object circe extends BsonCirceCodec
+
+trait BsonCirceCodec {
+  implicit def scalaCacheBsonCodecFromCirceCodec[A](implicit
+      encoder: io.circe.Encoder[A],
+      decoder: io.circe.Decoder[A]
+  ): BsonCodec[A] =
+    new BsonCodec[A] {
+
+      override def encode(value: A): BsonValue = {
+        val json = encoder(value)
+        jsonToBson(json)
+      }
+
+      override def decode(bytes: BsonValue): Codec.DecodingResult[A] = {
+        val json = bsonToJson(bytes)
+
+        decoder
+          .decodeJson(json)
+          .left
+          .map(FailedToDecode.apply)
+      }
+
+    }
+
+  private def bsonToJson(bson: BsonValue): Json = bson match {
+    case _: BsonNull        => Json.Null
+    case b: BsonBoolean     => Json.fromBoolean(b.getValue)
+    case i: BsonInt32       => Json.fromInt(i.getValue)
+    case l: BsonInt64       => Json.fromLong(l.getValue)
+    case d: BsonDouble      => Json.fromDoubleOrNull(d.getValue)
+    case bd: BsonDecimal128 => Json.fromBigDecimal(bd.getValue.bigDecimalValue)
+    case s: BsonString      => Json.fromString(s.getValue)
+    case a: BsonArray       => Json.fromValues(a.getValues.asScala.map(bsonToJson))
+    case d: BsonDocument =>
+      Json.fromJsonObject(
+        JsonObject.fromIterable(
+          d.entrySet.asScala.map { entry =>
+            entry.getKey -> bsonToJson(entry.getValue)
+          }
+        )
+      )
+  }
+
+  private def jsonToBson(json: Json): BsonValue = {
+    val toBsonFolder = new Json.Folder[BsonValue] {
+      def onNull: BsonValue =
+        new BsonNull()
+
+      def onBoolean(value: Boolean): BsonValue =
+        new BsonBoolean(value)
+
+      def onNumber(value: JsonNumber): BsonValue = {
+        value.toBigDecimal
+          .map { bd =>
+            if (bd.isValidInt) new BsonInt32(bd.intValue)
+            else if (bd.isValidLong) new BsonInt64(bd.longValue)
+            else if (bd.isDecimalDouble) new BsonDouble(bd.doubleValue)
+            else new BsonString(bd.toString)
+          }
+          .getOrElse {
+            new BsonString(value.toString)
+          }
+      }
+
+      def onString(value: String): BsonValue =
+        new BsonString(value)
+
+      def onArray(value: Vector[Json]): BsonValue = {
+        val bsonArray = new BsonArray()
+        value.foreach { v =>
+          bsonArray.add(v.foldWith(this))
+        }
+        bsonArray
+      }
+
+      def onObject(value: JsonObject): BsonValue = {
+        val bsonDocument = new BsonDocument()
+        value.toIterable.foreach { case (k, v) =>
+          bsonDocument.append(k, v.foldWith(this))
+        }
+        bsonDocument
+      }
+
+    }
+
+    json.foldWith(toBsonFolder)
+  }
+}

--- a/modules/mongo-circe/src/main/scala/scalacache/serialization/bson/circe.scala
+++ b/modules/mongo-circe/src/main/scala/scalacache/serialization/bson/circe.scala
@@ -95,7 +95,8 @@ trait BsonCirceCodec {
             else new BsonString(bd.toString)
           }
           .getOrElse {
-            new BsonString(value.toString)
+            // Should not be possible; these numbers are the result of encoding Java primitives
+            throw new NumberFormatException("For input string \"" + value.toString + "\"")
           }
       }
 

--- a/modules/mongo-circe/src/test/scala/scalacache/serialization/bson/circe/BsonCirceCodecSpec.scala
+++ b/modules/mongo-circe/src/test/scala/scalacache/serialization/bson/circe/BsonCirceCodecSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 scalacache
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scalacache.serialization
+
+import org.scalacheck.Arbitrary
+import org.scalatest.compatible.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import scalacache.serialization.bson.BsonCodec
+
+case class Fruit(name: String, tastinessQuotient: Double)
+
+class BsonCirceCodecSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+
+  behavior of "BSON serialization using circe"
+
+  import scalacache.serialization.bson.circe._
+
+  private def serdesCheck[A: Arbitrary](implicit codec: BsonCodec[A]): Assertion = {
+    forAll(minSuccessful(10000)) { (a: A) =>
+      val deserialised = codec.decode(codec.encode(a))
+      deserialised.toOption.get shouldBe a
+    }
+  }
+
+  it should "serialize and deserialize Ints" in {
+    serdesCheck[Int]
+  }
+
+  it should "serialize and deserialize Longs" in {
+    serdesCheck[Long]
+  }
+
+  it should "serialize and deserialize Doubles" in {
+    serdesCheck[Double]
+  }
+
+  it should "serialize and deserialize Floats" in {
+    serdesCheck[Float]
+  }
+
+  it should "serialize and deserialize BigDecimals" in {
+    serdesCheck[BigDecimal]
+  }
+
+  it should "serialize and deserialize BigInts" in {
+    serdesCheck[BigInt]
+  }
+
+  it should "serialize and deserialize Booleans" in {
+    serdesCheck[Boolean]
+  }
+
+  it should "serialize and deserialize Char" in {
+    serdesCheck[Char]
+  }
+
+  it should "serialize and deserialize Short" in {
+    serdesCheck[Short]
+  }
+
+  it should "serialize and deserialize String" in {
+    serdesCheck[String]
+  }
+
+  it should "serialize and deserialize Array[Byte]" in {
+    serdesCheck[Array[Byte]]
+  }
+
+  it should "serialize and deserialize a case class" in {
+    import io.circe.generic.auto._
+    val fruitCodec   = implicitly[BsonCodec[Fruit]]
+    val banana       = Fruit("banana", 0.7)
+    val deserialised = fruitCodec.decode(fruitCodec.encode(banana))
+    deserialised.toOption.get shouldBe banana
+  }
+}

--- a/modules/mongo-circe/src/test/scala/scalacache/serialization/bson/circe/BsonCirceCodecSpec.scala
+++ b/modules/mongo-circe/src/test/scala/scalacache/serialization/bson/circe/BsonCirceCodecSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scalacache.serialization.bson.BsonCodec
+import scalacache.serialization.bson.BsonEncoder
 
 sealed abstract class Item                                            extends Product with Serializable
 case class Fruit(name: String, tastinessQuotient: Option[BigDecimal]) extends Item
@@ -32,6 +33,8 @@ case class Basket(contents: Set[Purchase])
 sealed abstract class FolderEntry                           extends Product with Serializable
 case class Folder(name: String, contents: Set[FolderEntry]) extends FolderEntry
 case class File(name: String)                               extends FolderEntry
+
+case class Wrapper(string: String) extends AnyVal
 
 class BsonCirceCodecSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
@@ -44,6 +47,14 @@ class BsonCirceCodecSpec extends AnyFlatSpec with Matchers with ScalaCheckDriven
       val deserialised = codec.decode(codec.encode(a))
       deserialised.toOption.get shouldBe a
     }
+  }
+
+  it should "produce BSON encoders from Circe encoders" in {
+    import io.circe.generic.semiauto._
+
+    implicit val encoder: io.circe.Encoder[Wrapper] = deriveEncoder[Wrapper]
+
+    implicitly[BsonEncoder[Wrapper]]
   }
 
   it should "serialize and deserialize Ints" in {

--- a/modules/mongo-circe/src/test/scala/scalacache/serialization/bson/circe/BsonCirceCodecSpec.scala
+++ b/modules/mongo-circe/src/test/scala/scalacache/serialization/bson/circe/BsonCirceCodecSpec.scala
@@ -117,9 +117,13 @@ class BsonCirceCodecSpec extends AnyFlatSpec with Matchers with ScalaCheckDriven
   }
 
   it should "serialize and deserialize a recursive case class" in {
-    import io.circe.generic.auto._
+    import io.circe.generic.semiauto._
 
-    val folderEntryCodec = implicitly[BsonCodec[FolderEntry]]
+    // Circe auto derivation of recursive case classes does not work on Scala 3.x
+    implicit lazy val folderEntryCirceCodec: io.circe.Codec[FolderEntry] =
+      deriveCodec[FolderEntry]
+
+    val folderEntryCodec: BsonCodec[FolderEntry] = implicitly[BsonCodec[FolderEntry]]
 
     val folder = Folder("folder", Set(File("foo.txt"), Folder("subfolder", Set(File("bar.txt"))), File("baz.txt")))
 

--- a/modules/mongo/src/main/scala/scalacache/mongo/MongoCache.scala
+++ b/modules/mongo/src/main/scala/scalacache/mongo/MongoCache.scala
@@ -30,12 +30,14 @@ class MongoCache[F[_]: Async, V](client: MongoClient, databaseName: String, coll
     val codec: BsonCodec[V]
 ) extends AbstractCache[F, String, V] {
 
-  val collection = client.getDatabase(databaseName).getCollection(collectionName)
-
   protected def F: Async[F] = Async[F]
 
-  override protected final val logger =
+  protected final val logger =
     Logger.getLogger[F](getClass.getName)
+
+  private val collection = client
+    .getDatabase(databaseName)
+    .getCollection(collectionName)
 
   override protected def doGet(key: String): F[Option[V]] = {
     F.rethrow {
@@ -69,6 +71,5 @@ class MongoCache[F[_]: Async, V](client: MongoClient, databaseName: String, coll
 }
 
 object MongoCache {
-  // case class Entry[V](key: String, value: V, creationTime: Instant)
 
 }

--- a/modules/mongo/src/main/scala/scalacache/mongo/MongoCache.scala
+++ b/modules/mongo/src/main/scala/scalacache/mongo/MongoCache.scala
@@ -70,6 +70,4 @@ class MongoCache[F[_]: Async, V](client: MongoClient, databaseName: String, coll
   override def close: F[Unit] = F.delay(client.close())
 }
 
-object MongoCache {
-
-}
+object MongoCache {}

--- a/modules/mongo/src/main/scala/scalacache/mongo/MongoCache.scala
+++ b/modules/mongo/src/main/scala/scalacache/mongo/MongoCache.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 scalacache
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scalacache.mongo
+
+import cats.effect.{Async, Sync}
+import org.mongodb.scala.MongoClient
+import org.mongodb.scala.model.Filters
+import scalacache.AbstractCache
+import scalacache.logging.Logger
+import scalacache.serialization.bson.BsonCodec
+
+import java.time.Instant
+import scala.concurrent.duration.Duration
+
+class MongoCache[F[_]: Async, V](client: MongoClient, databaseName: String, collectionName: String)(implicit
+    val codec: BsonCodec[V]
+) extends AbstractCache[F, String, V] {
+
+  val collection = client.getDatabase(databaseName).getCollection(collectionName)
+
+  protected def F: Async[F] = Async[F]
+
+  override protected final val logger =
+    Logger.getLogger[F](getClass.getName)
+
+  override protected def doGet(key: String): F[Option[V]] = {
+    F.fromFuture(
+      F.delay(
+        collection
+          .find(Filters.eq("_id", key))
+          .map { document =>
+            val valueField = document("value")
+            codec.decode(valueField) match {
+              case Left(decodingError) => throw decodingError
+              case Right(value)        => value
+            }
+          }
+          .headOption()
+      )
+    )
+
+  }
+
+  override protected def doPut(key: String, value: V, ttl: Option[Duration]): F[Unit] = ???
+
+  override protected def doRemove(key: String): F[Unit] = ???
+
+  override protected def doRemoveAll: F[Unit] = ???
+
+  /** You should call this when you have finished using this Cache. (e.g. when your application shuts down)
+    *
+    * It will take care of gracefully shutting down the underlying cache client.
+    *
+    * Note that you should not try to use this Cache instance after you have called this method.
+    */
+
+  override def close: F[Unit] = F.delay(client.close())
+}
+
+object MongoCache {
+  // case class Entry[V](key: String, value: V, creationTime: Instant)
+
+}

--- a/modules/mongo/src/main/scala/scalacache/serialization/bson/BsonCodec.scala
+++ b/modules/mongo/src/main/scala/scalacache/serialization/bson/BsonCodec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 scalacache
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scalacache.serialization.bson
+
+import org.bson.BsonValue
+import scalacache.serialization.{Codec, Decoder, Encoder}
+import org.bson.conversions.Bson
+
+trait BsonEncoder[T] extends Encoder[T, BsonValue] {
+  override def encode(value: T): BsonValue
+}
+
+trait BsonDecoder[T] extends Decoder[T, BsonValue] {
+  override def decode(value: BsonValue): Codec.DecodingResult[T]
+}
+
+trait BsonCodec[T] extends Codec[T, BsonValue] with BsonEncoder[T] with BsonDecoder[T] {
+  override def encode(value: T): BsonValue
+  override def decode(bytes: BsonValue): Codec.DecodingResult[T]
+}

--- a/modules/mongo/src/main/scala/scalacache/serialization/bson/BsonCodec.scala
+++ b/modules/mongo/src/main/scala/scalacache/serialization/bson/BsonCodec.scala
@@ -17,8 +17,9 @@
 package scalacache.serialization.bson
 
 import org.bson.BsonValue
-import scalacache.serialization.{Codec, Decoder, Encoder}
-import org.bson.conversions.Bson
+import scalacache.serialization.Codec
+import scalacache.serialization.Decoder
+import scalacache.serialization.Encoder
 
 trait BsonEncoder[T] extends Encoder[T, BsonValue] {
   override def encode(value: T): BsonValue

--- a/modules/mongo/src/test/scala/scalacache/mongo/MongoCacheSpec.scala
+++ b/modules/mongo/src/test/scala/scalacache/mongo/MongoCacheSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 scalacache
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package scalacache.mongo
 
 import cats.effect.IO

--- a/modules/mongo/src/test/scala/scalacache/mongo/MongoCacheSpec.scala
+++ b/modules/mongo/src/test/scala/scalacache/mongo/MongoCacheSpec.scala
@@ -1,0 +1,68 @@
+package scalacache.mongo
+
+import cats.effect.IO
+import com.mongodb.client.model.Filters
+import com.mongodb.client.{MongoClients => SyncClients}
+import org.mongodb.scala.{MongoClient => ScalaClient}
+import org.bson.{BsonInt32, BsonValue, Document}
+import org.bson.conversions.Bson
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scalacache.serialization.Codec
+import scalacache.serialization.Codec.DecodingResult
+import scalacache.serialization.bson.BsonCodec
+
+import java.time.Instant
+
+class MongoCacheSpec
+    extends AnyFlatSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with IntegrationPatience {
+
+  val databaseName   = "Test-Database"
+  val mongoUri       = "mongodb://localhost:27017"
+  val syncClient     = SyncClients create (mongoUri)
+  val database       = syncClient.getDatabase(databaseName)
+  val collectionName = "Test-Cache"
+  val collection     = database.getCollection(collectionName)
+  val scalaClient    = ScalaClient (mongoUri)
+  implicit val bsonIntCodec: BsonCodec[Int] = new BsonCodec[Int] {
+    override def encode(value: Int): BsonValue = new BsonInt32(value)
+
+    override def decode(bytes: BsonValue): DecodingResult[Int] = Codec.tryDecode(bytes.asInt32().getValue)
+  }
+
+  override def afterAll() = {
+    syncClient.close()
+  }
+
+  override def beforeAll() = {
+    collection.deleteMany(Filters.empty())
+  }
+
+  import cats.effect.unsafe.implicits.global
+
+  behavior of "get"
+
+  it should "return the value stored in Mongodb" in {
+    val document = new Document()
+      .append("_id", "key1")
+      .append("value", 123)
+      .append("expiresAt", Instant.now)
+    collection.insertOne(document)
+    whenReady(new MongoCache[IO, Int](scalaClient,databaseName,collectionName).get("key1").unsafeToFuture()) {
+      _ should be(Some(123))
+    }
+  }
+
+  it should "return None if the given key does not exist in the underlying cache" in {
+    whenReady(new MongoCache[IO, Int](scalaClient,databaseName,collectionName).get("non-existent-key").unsafeToFuture()) {
+      _ should be(None)
+    }
+  }
+
+}

--- a/modules/mongo/src/test/scala/scalacache/mongo/MongoCacheSpec.scala
+++ b/modules/mongo/src/test/scala/scalacache/mongo/MongoCacheSpec.scala
@@ -37,9 +37,11 @@ class MongoCacheSpec
   val collection = database.getCollection(collectionName)
 
   implicit val bsonIntCodec: BsonCodec[Int] = new BsonCodec[Int] {
-    override def encode(value: Int): BsonValue = new BsonInt32(value)
+    override def encode(value: Int): BsonValue =
+      new BsonInt32(value)
 
-    override def decode(bytes: BsonValue): DecodingResult[Int] = Codec.tryDecode(bytes.asInt32().getValue)
+    override def decode(bytes: BsonValue): DecodingResult[Int] =
+      Codec.tryDecode(bytes.asInt32().getValue)
   }
 
   override def beforeAll() = {

--- a/modules/mongo/src/test/scala/scalacache/mongo/MongoCacheSpec.scala
+++ b/modules/mongo/src/test/scala/scalacache/mongo/MongoCacheSpec.scala
@@ -108,8 +108,7 @@ class MongoCacheSpec
   behavior of "put with TTL"
 
   it should "store the given key-value pair in the underlying cache" in {
-    whenReady(MongoCache[IO, Int](scalaClient, databaseName, collectionName).unsafeToFuture()) {
-      mongoCache =>
+    whenReady(MongoCache[IO, Int](scalaClient, databaseName, collectionName).unsafeToFuture()) { mongoCache =>
       whenReady(mongoCache.put("key3")(123, Some(3.seconds)).unsafeToFuture()) { _ =>
         val document = collection.find(Filters.eq("_id", "key3")).first()
 

--- a/modules/mongo/src/test/scala/scalacache/mongo/MongoCacheSpec.scala
+++ b/modules/mongo/src/test/scala/scalacache/mongo/MongoCacheSpec.scala
@@ -114,8 +114,9 @@ class MongoCacheSpec
 
         document.getInteger("value") should be(123)
 
-        // mongoDB expiry checks do not run extremely often
-        eventually(timeout(Span(60, Seconds))) {
+        // MongoDB TTL expiry checks do not run extremely often
+        // For more details see https://docs.mongodb.com/manual/core/index-ttl/#timing-of-the-delete-operation
+        eventually(timeout(Span(65, Seconds))) {
           val document = collection.find(Filters.eq("_id", "key3")).first()
 
           document should be(null)

--- a/modules/mongo/src/test/scala/scalacache/mongo/MongoCacheSpec.scala
+++ b/modules/mongo/src/test/scala/scalacache/mongo/MongoCacheSpec.scala
@@ -3,11 +3,13 @@ package scalacache.mongo
 import cats.effect.IO
 import com.mongodb.client.model.Filters
 import com.mongodb.client.{MongoClients => SyncClients}
+import org.bson.BsonInt32
+import org.bson.BsonValue
+import org.bson.Document
 import org.mongodb.scala.{MongoClient => ScalaClient}
-import org.bson.{BsonInt32, BsonValue, Document}
-import org.bson.conversions.Bson
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scalacache.serialization.Codec
@@ -23,28 +25,34 @@ class MongoCacheSpec
     with ScalaFutures
     with IntegrationPatience {
 
-  val databaseName   = "Test-Database"
-  val mongoUri       = "mongodb://localhost:27017"
-  val syncClient     = SyncClients create (mongoUri)
-  val database       = syncClient.getDatabase(databaseName)
   val collectionName = "Test-Cache"
-  val collection     = database.getCollection(collectionName)
-  val scalaClient    = ScalaClient (mongoUri)
+  val databaseName   = "Test-Database"
+
+  val mongoUri = "mongodb://localhost:27017"
+
+  val syncClient  = SyncClients.create(mongoUri)
+  val scalaClient = ScalaClient(mongoUri)
+
+  val database   = syncClient.getDatabase(databaseName)
+  val collection = database.getCollection(collectionName)
+
   implicit val bsonIntCodec: BsonCodec[Int] = new BsonCodec[Int] {
     override def encode(value: Int): BsonValue = new BsonInt32(value)
 
     override def decode(bytes: BsonValue): DecodingResult[Int] = Codec.tryDecode(bytes.asInt32().getValue)
   }
 
-  override def afterAll() = {
-    syncClient.close()
-  }
-
   override def beforeAll() = {
     collection.deleteMany(Filters.empty())
   }
 
+  override def afterAll() = {
+    syncClient.close()
+  }
+
   import cats.effect.unsafe.implicits.global
+
+  val mongoCache = new MongoCache[IO, Int](scalaClient, databaseName, collectionName)
 
   behavior of "get"
 
@@ -53,14 +61,16 @@ class MongoCacheSpec
       .append("_id", "key1")
       .append("value", 123)
       .append("expiresAt", Instant.now)
+
     collection.insertOne(document)
-    whenReady(new MongoCache[IO, Int](scalaClient,databaseName,collectionName).get("key1").unsafeToFuture()) {
+
+    whenReady(mongoCache.get("key1").unsafeToFuture()) {
       _ should be(Some(123))
     }
   }
 
   it should "return None if the given key does not exist in the underlying cache" in {
-    whenReady(new MongoCache[IO, Int](scalaClient,databaseName,collectionName).get("non-existent-key").unsafeToFuture()) {
+    whenReady(mongoCache.get("non-existent-key").unsafeToFuture()) {
       _ should be(None)
     }
   }

--- a/modules/tests/src/test/scala/integrationtests/IntegrationTests.scala
+++ b/modules/tests/src/test/scala/integrationtests/IntegrationTests.scala
@@ -134,7 +134,7 @@ class IntegrationTests extends AnyFlatSpec with Matchers with BeforeAndAfterAll 
           import scalacache.serialization.bson.circe._
           CacheBackend(
             "(Mongo) ⇔ (circe BSON codec)",
-            MongoCache[CatsIO, String](mongoClientSettings, "scalacache-test", "cache").unsafeRunSync()
+            MongoCache[CatsIO, String, String](mongoClientSettings, "scalacache-test", "cache").unsafeRunSync()
           )
         }
       )


### PR DESCRIPTION
This PR adds support for MongoDB as a cache implementation.

The cache is implemented as a MongoDB collection. The user must specify the database name and collection name to use for their cache.

Cache entries are created in the following format:

```
{
  "_id": <key>, // This is Mongo's unique key field which is indexed by default
  "value": <value>,
  "expiresAt": <current time + TTL value if provided, else null>
}
```

MongoDB uses [BSON](https://bsonspec.org/) as its serialization format. In order to capture this a `BsonCodec` type was added to this library along with `BsonEncoder` and `BsonDecoder`.

An integration module `scalacache-mongo-circe` has been provided which provides `BsonCodec` given an `io.circe.Codec`. This is done by converting `io.circe.Json` into `org.bson.BsonValue` and vice versa.

Document expiry is done using MongoDB's support for [TTL indexes](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-at-a-specific-clock-time). 

A TTL index is created for the `expiresAt` field with the `expireAfterSeconds` property set to `0`. This indicates to Mongo that the document should be expired at the timestamp stored in the field. 

When cache entries are inserted, the TTL value provided is added to the current time to establish the expiry time for that entry. If no TTL was provided, the field is null and the document does not expire.

Contributed by @rabinarai1 and myself on behalf of the @opencastsoftware open source team. 👋

BTW, we have noticed that this project is in between releases. I can see that #336 is tracking the progress on that. We'd be happy to help if there is anything we can pick up?