### PR TITLE
Extend Cache interface with Option-specific use case

### DIFF
--- a/modules/core/src/main/scala/scalacache/AbstractCache.scala
+++ b/modules/core/src/main/scala/scalacache/AbstractCache.scala
@@ -96,26 +96,42 @@ trait AbstractCache[F[_], K, V] extends Cache[F, K, V] with LoggingSupport[F, K]
       key: K
   )(ttl: Option[Duration] = None)(f: => V)(implicit flags: Flags): F[V] = cachingF(key)(ttl)(Sync[F].delay(f))
 
+  final override def cachingOption(
+      key: K
+  )(ttl: Option[Duration] = None)(f: => Option[V])(implicit flags: Flags): F[Option[V]] =
+    cachingFOption(key)(ttl)(Sync[F].delay(f))
+
   override def cachingF(
       key: K
-  )(ttl: Option[Duration] = None)(f: F[V])(implicit flags: Flags): F[V] = {
-    checkFlagsAndGet(key)
-      .handleErrorWith { e =>
-        logger
-          .ifWarnEnabled(logger.warn(s"Failed to read from cache. Key = $key", e))
-          .as(None)
+  )(ttl: Option[Duration] = None)(f: F[V])(implicit flags: Flags): F[V] =
+    read(key).flatMap {
+      case Some(valueFromCache) => F.pure(valueFromCache)
+      case None                 => f.flatTap(write(key, _, ttl))
+    }
+
+  override def cachingFOption(
+      key: K
+  )(ttl: Option[Duration] = None)(f: F[Option[V]])(implicit flags: Flags): F[Option[V]] =
+    read(key).flatMap {
+      case Some(valueFromCache) => F.pure(Some(valueFromCache))
+      case None => f.flatTap {
+        case Some(calculatedValue) => write(key, calculatedValue, ttl)
+        case None => logger.ifDebugEnabled(logger.debug("Calculated value was empty, not writing into cache")).void
       }
-      .flatMap {
-        case Some(valueFromCache) => F.pure(valueFromCache)
-        case None =>
-          f.flatTap { calculatedValue =>
-            checkFlagsAndPut(key, calculatedValue, ttl)
-              .handleErrorWith { e =>
-                logger.ifWarnEnabled {
-                  logger.warn(s"Failed to write to cache. Key = $key", e)
-                }.void
-              }
-          }
-      }
-  }
+    }
+
+  private def read(key: K) =
+    checkFlagsAndGet(key).handleErrorWith { e =>
+      logger
+        .ifWarnEnabled(logger.warn(s"Failed to read from cache. Key = $key", e))
+        .as(None)
+    }
+
+  private def write(key: K, value: V, ttl: Option[Duration] = None)(implicit flags: Flags) =
+    checkFlagsAndPut(key, value, ttl).handleErrorWith { e =>
+      logger.ifWarnEnabled {
+        logger.warn(s"Failed to write to cache. Key = $key", e)
+      }.void
+    }
+
 }

--- a/modules/core/src/main/scala/scalacache/Cache.scala
+++ b/modules/core/src/main/scala/scalacache/Cache.scala
@@ -80,6 +80,21 @@ trait Cache[F[_], K, V] {
     */
   def caching(key: K)(ttl: Option[Duration])(f: => V)(implicit flags: Flags): F[V]
 
+  /** Get a value from the cache if it exists. Otherwise compute it, insert it into the cache (only when it isn't None), and return it.
+    *
+    * @param key
+    *   The cache key
+    * @param ttl
+    *   The time-to-live to use when inserting into the cache. The cache entry will expire after this time has elapsed.
+    * @param f
+    *   A block that computes the value
+    * @param flags
+    *   Flags used to conditionally alter the behaviour of ScalaCache
+    * @return
+    *   The value, either retrieved from the cache or computed
+    */
+  def cachingOption(key: K)(ttl: Option[Duration])(f: => Option[V])(implicit flags: Flags): F[Option[V]]
+
   /** Get a value from the cache if it exists. Otherwise compute it, insert it into the cache, and return it.
     *
     * @param key
@@ -94,6 +109,21 @@ trait Cache[F[_], K, V] {
     *   The value, either retrieved from the cache or computed
     */
   def cachingF(key: K)(ttl: Option[Duration])(f: F[V])(implicit flags: Flags): F[V]
+
+  /** Get a value from the cache if it exists. Otherwise compute it, insert it into the cache (only when it isn't None), and return it.
+    *
+    * @param key
+    *   The cache key
+    * @param ttl
+    *   The time-to-live to use when inserting into the cache. The cache entry will expire after this time has elapsed.
+    * @param f
+    *   A block that computes the value
+    * @param flags
+    *   Flags used to conditionally alter the behaviour of ScalaCache
+    * @return
+    *   The value, either retrieved from the cache or computed
+    */
+  def cachingFOption(key: K)(ttl: Option[Duration])(f: F[Option[V]])(implicit flags: Flags): F[Option[V]]
 
   /** You should call this when you have finished using this Cache. (e.g. when your application shuts down)
     *


### PR DESCRIPTION
This PR extends Cache interface with two new methods - `cachingOption` and `cachingFOption` (these are draft names). They add a new behavior specific for computation that can return empty value, but it can change at an unspecified time in the future and in that case we would like to attempt the computation again instead of just reading `None` from the cache.

